### PR TITLE
Enh: Distributed agents

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,25 @@
+default_language_version:
+    python: python3
+repos:
+  - repo: https://github.com/ambv/black
+    rev: 22.12.0
+    hooks:
+      - id: black
+  - repo: https://github.com/pycqa/flake8
+    rev: 6.0.0
+    hooks:
+      - id: flake8
+  - repo: https://github.com/pycqa/isort
+    rev: 5.11.2
+    hooks:
+      - id: isort
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
+    hooks:
+    - id: check-yaml
+    - id: end-of-file-fixer
+    - id: trailing-whitespace
+  - repo: https://github.com/kynan/nbstripout
+    rev: 0.3.9
+    hooks:
+      - id: nbstripout

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,6 +13,7 @@ repos:
     rev: 5.11.2
     hooks:
       - id: isort
+        args: ["--profile", "black", "--filter-files"]
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0
     hooks:

--- a/bluesky_adaptive/agents/base.py
+++ b/bluesky_adaptive/agents/base.py
@@ -84,10 +84,12 @@ class AgentConsumer(RemoteDispatcher):
         try:
             getattr(self._agent, action)(*args, **kwargs)
         except AttributeError as e:
-            logger.error(f"Unavailable action sent to agent {self._agent.agent_name} on topic: {topic}\n" f"{e}")
+            logger.error(
+                f"Unavailable action sent to agent {self._agent.instance_name} on topic: {topic}\n" f"{e}"
+            )
         except TypeError as e:
             logger.error(
-                f"Type error for {action} sent to agent {self._agent.agent_name} on topic: {topic}\n"
+                f"Type error for {action} sent to agent {self._agent.instance_name} on topic: {topic}\n"
                 f"Are you sure your args and kwargs were appropriate?\n"
                 f"Args received: {args}\n"
                 f"Kwargs received: {kwargs}\n"
@@ -118,7 +120,7 @@ class AgentConsumer(RemoteDispatcher):
         continue_polling : bool
             return False to break out of the polling loop, return True to continue polling
         """
-        if name == self._agent.agent_name:
+        if name == self._agent.instance_name:
             return self._agent_action(topic, doc)
         else:
             return super().process_document(consumer, topic, name, doc)
@@ -246,8 +248,9 @@ class Agent(ABC):
 
         self.metadata = metadata or {}
         self.instance_name = (
-            f"{self.name}-agent_name"
-            or f"{self.name}-{xp.generate_xkcdpassword(PASSWORD_LIST, numwords=2, delimiter='-')}"
+            f"{self.name}-{agent_name}"
+            if agent_name
+            else f"{self.name}-{xp.generate_xkcdpassword(PASSWORD_LIST, numwords=2, delimiter='-')}"
         )
         self.metadata["agent_name"] = self.instance_name
 

--- a/bluesky_adaptive/agents/base.py
+++ b/bluesky_adaptive/agents/base.py
@@ -9,7 +9,7 @@ import msgpack
 from bluesky_kafka import Publisher, RemoteDispatcher
 from bluesky_live.run_builder import RunBuilder
 from bluesky_queueserver_api import BPlan
-from bluesky_queueserver_api.http import REManagerAPI
+from bluesky_queueserver_api.api_threads import API_Threads_Mixin
 from databroker.client import BlueskyRun
 from numpy.typing import ArrayLike
 from tiled.client import from_profile
@@ -171,10 +171,8 @@ class Agent(ABC):
         Tiled profile name to serve as source of data (BlueskyRuns) for the agent.
     agent_profile_name : str
         Tiled profile name to serve as storage for the agent documents.
-    qserver_host : str
-        Host to POST requests to. Something akin to 'http://localhost:60610'
-    qserver_api_key : str
-        Key for API security.
+    qserver : bluesky_queueserver_api.api_threads.API_Threads_Mixin
+        Object to manage communication with Queue Server
     agent_name : Optional[str], optional
         Agent name suffix for the instance, by default generated using 2 hyphen separated words from xkcdpass.
     metadata : Optional[dict], optional
@@ -212,8 +210,7 @@ class Agent(ABC):
         subscripion_topics: List[str],
         data_profile_name: str,
         agent_profile_name: str,
-        qserver_host: str,
-        qserver_api_key: str,
+        qserver: API_Threads_Mixin,
         agent_name: Optional[str] = None,
         metadata: Optional[dict] = None,
         ask_on_tell: bool = True,
@@ -259,8 +256,7 @@ class Agent(ABC):
         self.default_report_kwargs = {} if default_report_kwargs is None else default_report_kwargs
 
         self.builder = None
-        self.re_manager = REManagerAPI(http_server_uri=qserver_host)
-        self.re_manager.set_authorization_key(api_key=qserver_api_key)
+        self.re_manager = qserver
         self._queue_add_position = "back" if queue_add_position is None else queue_add_position
         self._direct_to_queue = direct_to_queue
         self.default_plan_md = dict(

--- a/bluesky_adaptive/agents/base.py
+++ b/bluesky_adaptive/agents/base.py
@@ -96,7 +96,7 @@ class AgentConsumer(RemoteDispatcher):
             )
         return True
 
-    def process_document(self, topic, name, doc):
+    def process_document(self, consumer, topic, name, doc):
         """
         Processes bluesky documents.
         Optionally
@@ -118,11 +118,10 @@ class AgentConsumer(RemoteDispatcher):
         continue_polling : bool
             return False to break out of the polling loop, return True to continue polling
         """
-
         if name == self._agent.agent_name:
-            continue_polling = self._agent_action(topic, doc)
-
-        return super().process_document(topic, name, doc) or continue_polling
+            return self._agent_action(topic, doc)
+        else:
+            return super().process_document(consumer, topic, name, doc)
 
 
 class Agent(ABC):

--- a/bluesky_adaptive/agents/base.py
+++ b/bluesky_adaptive/agents/base.py
@@ -476,7 +476,7 @@ class Agent(ABC):
             kwargs["md"]["agent_ask_uid"] = uid
             plan = BPlan(
                 plan_name,
-                args,
+                *args,
                 **kwargs,
             )
             r = self.re_manager.item_add(plan, pos=self.queue_add_position)

--- a/bluesky_adaptive/agents/base.py
+++ b/bluesky_adaptive/agents/base.py
@@ -84,9 +84,9 @@ class AgentConsumer(RemoteDispatcher):
         try:
             getattr(self._agent, action)(*args, **kwargs)
         except AttributeError as e:
-            logger.warn(f"Unavailable action sent to agent {self._agent.agent_name} on topic: {topic}\n" f"{e}")
+            logger.error(f"Unavailable action sent to agent {self._agent.agent_name} on topic: {topic}\n" f"{e}")
         except TypeError as e:
-            logger.warn(
+            logger.error(
                 f"Type error for {action} sent to agent {self._agent.agent_name} on topic: {topic}\n"
                 f"Are you sure your args and kwargs were appropriate?\n"
                 f"Args received: {args}\n"

--- a/bluesky_adaptive/agents/base.py
+++ b/bluesky_adaptive/agents/base.py
@@ -654,7 +654,7 @@ class Agent(ABC):
         return qserver
 
     @classmethod
-    def from_kwargs(
+    def from_config_kwargs(
         cls,
         kafka_group_id: str,
         kafka_bootstrap_servers: str,

--- a/bluesky_adaptive/agents/base.py
+++ b/bluesky_adaptive/agents/base.py
@@ -1,0 +1,662 @@
+import inspect
+import sys
+import uuid
+from abc import ABC, abstractmethod
+from argparse import ArgumentParser, RawDescriptionHelpFormatter
+from logging import getLogger
+from typing import Iterable, List, Literal, Optional, Sequence, Tuple, Union
+
+import msgpack
+from bluesky_kafka import Publisher, RemoteDispatcher
+from bluesky_live.run_builder import RunBuilder
+from bluesky_queueserver_api import BPlan
+from bluesky_queueserver_api.http import REManagerAPI
+from databroker.client import BlueskyRun
+from tiled.client import from_profile
+from xkcdpass import xkcd_password as xp
+
+logger = getLogger("bluesky_adaptive.agents")
+PASSWORD_LIST = xp.generate_wordlist(wordfile=xp.locate_wordfile(), min_length=3, max_length=6)
+
+
+class AgentConsumer(RemoteDispatcher):
+    def __init__(
+        self,
+        *,
+        topics,
+        bootstrap_servers,
+        group_id,
+        agent,
+        consumer_config=None,
+        polling_duration=0.05,
+        deserializer=msgpack.loads,
+    ):
+        """Dispatch documents from Kafka to bluesky callbacks, modified for agent usage.
+        This allows subscribing the dispatcher to an on-stop protocol for agents to be told about
+        new Bluesky runs. It also provides an interface to trigger changes to the agent using the same
+        Kafka topics.
+
+        Parameters
+        ----------
+        topics : list
+            List of topics as strings such as ["topic-1", "topic-2"]
+        bootstrap_servers : str
+            Comma-delimited list of Kafka server addresses as a string such as ``'127.0.0.1:9092'``
+        group_id : str
+            Required string identifier for Kafka Consumer group
+        agent : Agent
+            Instance of the agent to send directives to
+        consumer_config : dict
+            Override default configuration or specify additional configuration
+            options to confluent_kafka.Consumer.
+        polling_duration : float
+            Time in seconds to wait for a message before running function work_while_waiting.
+            Default is 0.05.
+        deserializer : function, optional
+            optional function to deserialize data. Default is msgpack.loads.
+        """
+        super().__init__(topics, bootstrap_servers, group_id, consumer_config, polling_duration, deserializer)
+        self._agent = agent
+
+    def _agent_action(self, topic, doc):
+        """Exposes agent methods via the kafka topic.
+        This allows bluesky plans, or adjudicators to interface with agent hyperparameters or settings.
+
+        Parameters
+        ----------
+        topic : str
+            the Kafka topic of the message containing name and doc
+        doc : dict
+            agent document expecting
+            {
+            'action': 'method_name',
+            'args': [arg1,arg2,...],
+            'kwargs': {kwarg1:val1, kwarg2:val2}
+            }
+
+        Returns
+        -------
+        continue_polling : bool
+        """
+        action = doc["action"]
+        args = doc["args"]
+        kwargs = doc["kwargs"]
+        try:
+            getattr(self._agent, action)(*args, **kwargs)
+        except AttributeError as e:
+            logger.warn(f"Unavailable action sent to agent {self._agent.agent_name} on topic: {topic}\n" f"{e}")
+        except TypeError as e:
+            logger.warn(
+                f"Type error for {action} sent to agent {self._agent.agent_name} on topic: {topic}\n"
+                f"Are you sure your args and kwargs were appropriate?\n"
+                f"Args received: {args}\n"
+                f"Kwargs received: {kwargs}\n"
+                f"Expected signature: {inspect.signature(getattr(self.agent, action))}\n"
+                f"{e}"
+            )
+        return True
+
+    def process_document(self, topic, name, doc):
+        """
+        Processes bluesky documents.
+        Optionally
+        Sends bluesky document to RemoteDispatcher.process(name, doc)
+        If this method returns False the BlueskyConsumer will break out of the
+        polling loop.
+
+        Parameters
+        ----------
+        topic : str
+            the Kafka topic of the message containing name and doc
+        name : str
+            bluesky document name: `start`, `descriptor`, `event`, etc.
+        doc : dict
+            bluesky document
+
+        Returns
+        -------
+        continue_polling : bool
+            return False to break out of the polling loop, return True to continue polling
+        """
+
+        if name == self._agent.agent_name:
+            continue_polling = self._agent_action(topic, doc)
+
+        return super().process_document(topic, name, doc) or continue_polling
+
+
+class Agent(ABC):
+    """Abstract base class for a single plan agent. These agents should consume data, decide where to measure next,
+    and execute a single type of plan (something akin to move and count).
+    Alternatively, these agents can be used for soley reporting.
+
+    Base agent sets up a kafka subscription to listen to new stop documents, a catalog to read for experiments,
+    a catalog to write agent status to, a kafka publisher to write agent documents to,
+    and a manager API for the queue-server. Each time a stop document is read,
+    the respective BlueskyRun is unpacked by the ``unpack_run`` method into an independent and dependent variable,
+    and told to the agent by the ``tell`` method.
+
+    Children of Agent should implment the following, through direct inheritence or mixin classes:
+    - measurement_plan_name
+    - measurement_plan_args
+    - measurement_plan_kwargs
+    - unpack_run
+    - tell
+    - ask
+    - report (optional)
+    - name (optional)
+
+    Parameters
+    ----------
+    kafka_group_id : str
+        Required string identifier for the consumer's Kafka Consumer group.
+    kafka_bootstrap_servers : str
+        Comma-delimited list of Kafka server addresses as a string
+        such as ``'broker1:9092,broker2:9092,127.0.0.1:9092'``
+    kafka_consumer_config : dict
+        Override default configuration or specify additional configuration
+        options to confluent_kafka.Consumer.
+    kafka_producer_config : dict
+        Override default configuration or specify additional configuration
+        options to confluent_kafka.Producer.
+    publisher_topic : str
+        Existing topic to publish agent documents to.
+    subscripion_topics : List[str]
+        List of existing_topics as strings such as ["topic-1", "topic-2"]. These should be
+        the sources of the Bluesky stop documents that trigger ``tell`` and agent directives.
+    data_profile_name : str
+        Tiled profile name to serve as source of data (BlueskyRuns) for the agent.
+    agent_profile_name : str
+        Tiled profile name to serve as storage for the agent documents.
+    qserver_host : str
+        Host to POST requests to. Something akin to 'http://localhost:60610'
+    qserver_api_key : str
+        Key for API security.
+    agent_name : Optional[str], optional
+        Agent name suffix for the instance, by default generated using 2 hyphen separated words from xkcdpass.
+    metadata : Optional[dict], optional
+        Optional extra metadata to add to agent start document, by default {}
+    ask_on_tell : bool, optional
+        Whether to ask for new points every time an agent is told about new data.
+        To create a truly passive agent, it is best to implement an ``ask`` as a method that does nothing.
+        To create an agent that only suggests new points periodically or on another trigger, ``ask_on_tell``
+        should be set to False.
+        By default True
+        Can be adjusted using ``enable_continuous_suggesting`` and ``disable_continuous_suggesting``.
+    direct_to_queue : Optional[bool], optional
+        Whether the agent suggestions will be placed directly on the queue. If false,
+        the suggestions will be sent to a Kafka topic for an Adjudicator to process.
+        By default True
+        Can be adjusted using ``enable_direct_to_queue`` and ``disable_direct_to_queue``.
+    report_on_tell : bool, optional
+        Whether to create a report every time an agent is told about new data.
+        By default False.
+        Can be adjusted using ``enable_continuous_reporting`` and ``disable_continuous_reporting``.
+    default_report_kwargs : Optional[dict], optional
+        Default kwargs for calling the ``report`` method, by default None
+    queue_add_position : Optional[Union[int, Literal[&quot;front&quot;, &quot;back&quot;]]], optional
+        Starting postion to add to the queue if adding directly to the queue, by default "back".
+    """
+
+    def __init__(
+        self,
+        *,
+        kafka_group_id: str,
+        kafka_bootstrap_servers: str,
+        kafka_consumer_config: dict,
+        kafka_producer_config: dict,
+        publisher_topic: str,
+        subscripion_topics: List[str],
+        data_profile_name: str,
+        agent_profile_name: str,
+        qserver_host: str,
+        qserver_api_key: str,
+        agent_name: Optional[str] = None,
+        metadata: Optional[dict] = None,
+        ask_on_tell: bool = True,
+        direct_to_queue: Optional[bool] = True,
+        report_on_tell: bool = False,
+        default_report_kwargs: Optional[dict] = None,
+        queue_add_position: Optional[Union[int, Literal["front", "back"]]] = None,
+    ):
+
+        logger.debug("Initializing agent.")
+        self.kafka_consumer = AgentConsumer(
+            topics=subscripion_topics,
+            bootstrap_servers=kafka_bootstrap_servers,
+            group_id=kafka_group_id,
+            consumer_config=kafka_consumer_config,
+            agent=self,
+        )
+        self.kafka_consumer.subscribe(self._on_stop_router)
+        self.kafka_producer = Publisher(
+            topic=publisher_topic,
+            bootstrap_servers=kafka_bootstrap_servers,
+            key="",
+            producer_config=kafka_producer_config,
+        )
+        logger.debug("Kafka set up successfully.")
+
+        self.exp_catalog = from_profile(data_profile_name)
+        logger.info(f"Reading data from catalog: {self.exp_catalog}")
+
+        self.agent_catalog = from_profile(agent_profile_name)
+        logger.info(f"Writing data to catalog: {self.agent_catalog}")
+
+        self.metadata = metadata or {}
+        self.metadata.update(
+            dict(
+                kafka_group_id=kafka_group_id,
+                kafka_bootstrap_servers=kafka_bootstrap_servers,
+                kafka_consumer_config=kafka_consumer_config,
+                kafka_producer_config=kafka_producer_config,
+            )
+        )
+        self.metadata["agent_name"] = self.agent_name = (
+            agent_name or f"{self.name}-{xp.generate_xkcdpassword(PASSWORD_LIST, numwords=2, delimiter='-')}"
+        )
+
+        self._ask_on_tell = ask_on_tell
+        self._report_on_tell = report_on_tell
+        self.default_report_kwargs = {} if default_report_kwargs is None else default_report_kwargs
+
+        self.builder = None
+        self.re_manager = REManagerAPI(http_server_uri=qserver_host)
+        self.re_manager.set_authorization_key(api_key=qserver_api_key)
+        self._queue_add_position = "back" if queue_add_position is None else queue_add_position
+        self._direct_to_queue = direct_to_queue
+        self.default_plan_md = dict(
+            agent_name=self.agent_name,
+            agent_class=str(type(self)),
+            tiled_data_profile=data_profile_name,
+            tiled_agent_profile=agent_profile_name,
+        )
+
+    @property
+    @abstractmethod
+    def measurement_plan_name(self) -> str:
+        """String name of registered plan"""
+        ...
+
+    @staticmethod
+    @abstractmethod
+    def measurement_plan_args(point) -> list:
+        """
+        List of arguments to pass to plan from a point to measure.
+        This is a good place to transform relative into absolute motor coords.
+        """
+        ...
+
+    @staticmethod
+    @abstractmethod
+    def measurement_plan_kwargs(point) -> dict:
+        """
+        Construct dictionary of keyword arguments to pass the plan, from a point to measure.
+        This is a good place to transform relative into absolute motor coords.
+        """
+        ...
+
+    @staticmethod
+    @abstractmethod
+    def unpack_run(run: BlueskyRun):
+        """
+        Consume a Bluesky run from tiled and emit the relevant x and y for the agent.
+
+        Parameters
+        ----------
+        run : BlueskyRun
+
+        Returns
+        -------
+        independent_var :
+            The independent variable of the measurement
+        dependent_var :
+            The measured data, processed for relevance
+        """
+        ...
+
+    @abstractmethod
+    def tell(self, x, y) -> dict:
+        """
+        Tell the agent about some new data
+        Parameters
+        ----------
+        x :
+            Independent variable for data observed
+        y :
+            Dependent variable for data observed
+
+        Returns
+        -------
+        dict
+            Dictionary to be unpacked or added to a document
+
+        """
+        ...
+
+    @abstractmethod
+    def ask(self, batch_size: int) -> Tuple[dict, Sequence]:
+        """
+        Ask the agent for a new batch of points to measure.
+
+        Parameters
+        ----------
+        batch_size : int
+            Number of new points to measure
+
+        Returns
+        -------
+        doc : dict
+            key metadata from the ask approach
+        next_points : Sequence
+            Sequence of independent variables of length batch size
+
+        """
+        ...
+
+    def report(self, **kwargs) -> dict:
+        """
+        Create a report given the data observed by the agent.
+        This could be potentially implemented in the base class to write document stream.
+        Additional functionality for converting the report dict into an image or formatted report is
+        the duty of the child class.
+        """
+
+        raise NotImplementedError
+
+    def tell_many(self, xs, ys) -> Sequence[dict]:
+        """
+        Tell the agent about some new data. It is likely that there is a more efficient approach to
+        handling multiple observations for an agent. The default behavior is to iterate over all
+        observations and call the ``tell`` method.
+
+        Parameters
+        ----------
+        xs : list, array
+            Array of independent variables for observations
+        ys : list, array
+            Array of dependent variables for observations
+
+        Returns
+        -------
+        list_of_dict
+
+        """
+        tell_emits = []
+        for x, y in zip(xs, ys):
+            tell_emits.append(self.tell(x, y))
+        return tell_emits
+
+    @property
+    def queue_add_position(self) -> Union[int, Literal["front", "back"]]:
+        return self._queue_add_position
+
+    @queue_add_position.setter
+    def queue_add_position(self, position: Union[int, Literal["front", "back"]]):
+        self._queue_add_position = position
+
+    def update_priority(self, position: Union[int, Literal["front", "back"]]):
+        """Convenience method to update the priority of a direct to queue agent
+
+        Parameters
+        ----------
+        position : Union[int, Literal[&quot;front&quot;, &quot;back&quot;]]
+            Position in priority for queue.
+        """
+        self.queue_add_position = position
+
+    @property
+    def ask_on_tell(self) -> bool:
+        return self._ask_on_tell
+
+    @ask_on_tell.setter
+    def ask_on_tell(self, flag: bool):
+        self._ask_on_tell = flag
+
+    @property
+    def report_on_tell(self) -> bool:
+        return self._report_on_tell
+
+    @report_on_tell.setter
+    def report_on_tell(self, flag: bool):
+        self._report_on_tell = flag
+
+    def enable_continuous_reporting(self):
+        """Enable agent to report each time it receives data."""
+        self.report_on_tell = True
+
+    def disable_continuous_reporting(self):
+        """Disable agent to report each time it receives data."""
+        self.report_on_tell = False
+
+    def enable_continuous_suggesting(self):
+        """Enable agent to suggest new points to the queue each time it receives data."""
+        self.ask_on_tell = True
+
+    def disable_continuous_suggesting(self):
+        """Disable agent to suggest new points to the queue each time it receives data."""
+        self.ask_on_tell = False
+
+    def enable_direct_to_queue(self):
+        self._direct_to_queue = True
+
+    def disable_direct_to_queue(self):
+        self._direct_to_queue = False
+
+    @property
+    def name(self) -> str:
+        """Short string name"""
+        return "agent"
+
+    @classmethod
+    def build_from_argparse(cls, parser: ArgumentParser, **kwargs):
+        args = parser.parse_args()
+        _kwargs = vars(args)
+        _kwargs.update(kwargs)
+        return cls.__init__(**_kwargs)
+
+    @classmethod
+    def constructor_argparser(cls) -> ArgumentParser:
+        """Convenience method to put all arguments into a parser"""
+        parser = ArgumentParser(description=cls.__doc__, formatter_class=RawDescriptionHelpFormatter)
+        parser.add_argument("--kafka-group-id", required=True)
+        parser.add_argument("--kafka-bootstrap-servers", required=True)
+        parser.add_argument("--kafka-consumer-config", required=True)
+        parser.add_argument("--kafka-producer-config", required=True)
+        parser.add_argument("--publisher-topic", required=True)
+        parser.add_argument("--subscription-topics", required=True)
+        parser.add_argument("--data-profile-name", required=True)
+        parser.add_argument("--agent-profile-name", required=True)
+        parser.add_argument("--qserver-host", required=True)
+        parser.add_argument("--qserver-api-key", required=True)
+        parser.add_argument("--metadata")
+
+        return parser
+
+    def _write_event(self, stream, doc):
+        """Add event to builder as event page, and publish to catalog"""
+        uid = str(uuid.uuid4())
+        if not doc:
+            logger.info(f"No doc presented to write_event for stream {stream}")
+            return
+        if stream in self.builder._streams:
+            self.builder.add_data(stream, data=doc)
+        else:
+            self.builder.add_stream(stream, data=doc)
+            self.agent_catalog.v1.insert(*self.builder._cache._ordered[-2])  # Add descriptor for first time
+        self.agent_catalog.v1.insert(*self.builder._cache._ordered[-1])
+        return uid
+
+    def _add_to_queue(self, next_points, uid):
+        """
+        Adds a single set of points to the queue as bluesky plans
+
+        Parameters
+        ----------
+        next_points : Iterable
+            New points to measure
+        uid : str
+
+        Returns
+        -------
+
+        """
+        for point in next_points:
+            kwargs = self.measurement_plan_kwargs(point)
+            kwargs.setdefault("md", {})
+            kwargs["md"].update(self.default_plan_md)
+            kwargs["md"]["agent_ask_uid"] = uid
+            plan = BPlan(
+                self.measurement_plan_name,
+                *self.measurement_plan_args(point),
+                **kwargs,
+            )
+            r = self.re_manager.item_add(plan, pos=self.queue_add_position)
+            logger.debug(f"Sent http-server request for point {point}\n." f"Received reponse: {r}")
+        return
+
+    def _check_queue_and_start(self):
+        """
+        If the queue runs out of plans, it will stop.
+        That is, adding a plan to an empty queue will not run the plan.
+        This will not be an issue when there are many agents adding plans to a queue.
+        Giving agents the autonomy to start the queue is a risk that will be mitigated by
+        only allowing the beamline scientists to open and close the environment.
+        A queue cannot be started in a closed environment.
+        """
+        status = self.re_manager.status(reload=True)
+        if (
+            status["items_in_queue"] == 1
+            and status["worker_environment_exists"] is True
+            and status["manager_state"] == "idle"
+        ):
+            self.re_manager.queue_start()
+            logger.info("Agent is starting an idle queue with exactly 1 item.")
+
+    def add_suggestions_to_queue(self, batch_size: int):
+        """Calls ask, adds suggestions to queue, and writes out event"""
+        doc, next_points = self.ask(batch_size)
+        uid = self._write_event("ask", doc)
+        logger.info(f"Issued ask and adding to the queue. {uid}")
+        self._add_to_queue(next_points, uid)
+        self._check_queue_and_start()
+
+    def _create_suggestion_list(self, points, uid):
+        """Create suggestions for adjudicator"""
+        raise NotImplementedError
+        """Not implementing yet to lighten PR load. Copied is implementation from MMM.
+        suggestions = []
+        for point in points:
+            kwargs = self.measurement_plan_kwargs(point)
+            kwargs.setdefault("md", {})
+            kwargs["md"].update(self.default_plan_md)
+            kwargs["md"]["agent_ask_uid"] = uid
+            args = self.measurement_plan_args(point)
+            suggestions.append(
+                Suggestion(
+                    ask_uid=uid,
+                    plan_name=self.measurement_plan_name,
+                    plan_args=args,
+                    plan_kwargs=kwargs,
+                )
+            )
+        return suggestions
+        """
+
+    def generate_suggestions_for_adjudicator(self, batch_size: int):
+        raise NotImplementedError
+        """ Not implementing yet to lighten PR load. Copied is implementation from MMM.
+        doc, next_points = self.ask(batch_size)
+        uid = self._write_event("ask", doc)
+        logger.info(f"Issued ask and sending to adjudicator. {uid}")
+        suggestions = self._create_suggestion_list(next_points, uid)
+        msg = AdjudicatorMsg(
+            agent_name=self.agent_name,
+            suggestions_uid=str(uuid.uuid4()),
+            suggestions={self.beamline_tla: suggestions},
+        )
+        self.kafka_producer(ADJUDICATOR_STREAM_NAME, msg.dict())
+        """
+
+    def generate_report(self, **kwargs):
+        doc = self.report(**kwargs)
+        uid = self._write_event("report", doc)
+        logger.info(f"Issued report request and writing event. {uid}")
+
+    @staticmethod
+    def trigger_condition(uid) -> bool:
+        return True
+
+    def _on_stop_router(self, name, doc):
+        """Document router that runs each time a stop document is seen."""
+        if name != "stop":
+            return
+
+        uid = doc["run_start"]
+        if not self.trigger_condition(uid):
+            logger.debug(
+                f"New data detected, but trigger condition not met. The agent will ignore this start doc: {uid}"
+            )
+            return
+
+        logger.info(f"New data detected, telling the agent about this start doc: {uid}")
+        run = self.exp_catalog[uid]
+        try:
+            independent_variable, dependent_variable = self.unpack_run(run)
+        except KeyError as e:
+            logger.warning(f"Ignoring key error in unpack for data {uid}:\n {e}")
+            return
+
+        # Tell
+        logger.debug("Telling agent about some new data.")
+        doc = self.tell(independent_variable, dependent_variable)
+        doc["exp_uid"] = [uid]
+        self._write_event("tell", doc)
+
+        # Report
+        if self.report_on_tell:
+            self.generate_report(**self.default_report_kwargs)
+
+        # Ask
+        if self.ask_on_tell:
+            if self._direct_to_queue:
+                self.add_suggestions_to_queue(1)
+            else:
+                self.generate_suggestions_for_adjudicator(1)
+
+    def tell_agent_by_uid(self, uids: Iterable):
+        """Give an agent an iterable of uids to learn from.
+        This is an optional behavior for priming an agent without a complete restart."""
+        logger.info("Telling agent list of uids")
+        for uid in uids:
+            logger.info(f"Telling agent about start document{uid}")
+            run = self.exp_catalog[uid]
+            independent_variable, dependent_variable = self.unpack_run(run)
+            doc = self.tell(independent_variable, dependent_variable)
+            doc["exp_uid"] = [uid]
+            self._write_event("tell", doc)
+
+    def start(self, ask_at_start=False):
+        logger.debug("Issuing Agent start document and starting to listen to Kafka")
+        self.builder = RunBuilder(metadata=self.metadata)
+        self.agent_catalog.v1.insert("start", self.builder._cache.start_doc)
+        logger.info(f"Agent name={self.builder._cache.start_doc['agent_name']}")
+        logger.info(f"Agent start document uuid={self.builder._cache.start_doc['uid']}")
+        if ask_at_start:
+            self.add_suggestions_to_queue(1)
+        self.kafka_consumer.start()
+
+    def stop(self, exit_status="success", reason=""):
+        logger.debug("Attempting agent stop.")
+        self.builder.close(exit_status=exit_status, reason=reason)
+        self.agent_catalog.v1.insert("stop", self.builder._cache.stop_doc)
+        self.kafka_producer.flush()
+        self.kafka_consumer.stop()
+        logger.info(
+            f"Stopped agent with exit status {exit_status.upper()}"
+            f"{(' for reason: ' + reason) if reason else '.'}"
+        )
+
+    def signal_handler(self, signal, frame):
+        self.stop(exit_status="abort", reason="forced exit ctrl+c")
+        sys.exit(0)

--- a/bluesky_adaptive/agents/base.py
+++ b/bluesky_adaptive/agents/base.py
@@ -1,6 +1,5 @@
 import inspect
 import sys
-import uuid
 from abc import ABC, abstractmethod
 from argparse import ArgumentParser, RawDescriptionHelpFormatter
 from logging import getLogger
@@ -471,7 +470,8 @@ class Agent(ABC):
 
     def _write_event(self, stream, doc):
         """Add event to builder as event page, and publish to catalog"""
-        uid = str(uuid.uuid4())
+        for key in doc:
+            doc[key] = [doc[key]]  # Encapsulate everything in a list for event pages
         if not doc:
             logger.info(f"No doc presented to write_event for stream {stream}")
             return
@@ -481,7 +481,7 @@ class Agent(ABC):
             self.builder.add_stream(stream, data=doc)
             self.agent_catalog.v1.insert(*self.builder._cache._ordered[-2])  # Add descriptor for first time
         self.agent_catalog.v1.insert(*self.builder._cache._ordered[-1])
-        return uid
+        return self.builder._cache._ordered[-1][1]["uid"]
 
     def _add_to_queue(self, next_points, uid):
         """

--- a/bluesky_adaptive/agents/base.py
+++ b/bluesky_adaptive/agents/base.py
@@ -655,3 +655,27 @@ class Agent(ABC):
     def signal_handler(self, signal, frame):
         self.stop(exit_status="abort", reason="forced exit ctrl+c")
         sys.exit(0)
+
+    @staticmethod
+    def qserver_from_host_and_key(host: str, key: str):
+        """Convenience method to prouduce RE Manager object to manage communication with Queue Server.
+        This is one of several paradigms for communication, albeit a common one.
+        See bluesky_queueserver_api documentation for more details.
+
+
+        Parameters
+        ----------
+        host : str
+            URI for host of HTTP Server
+        key : str
+            Authorization key for HTTP Server API
+
+        Returns
+        -------
+        qserver : bluesky_queueserver_api.api_threads.API_Threads_Mixin
+        """
+        from bluesky_queueserver_api.http import REManagerAPI
+
+        qserver = REManagerAPI(http_server_uri=host)
+        qserver.set_authorization_key(api_key=key)
+        return qserver

--- a/bluesky_adaptive/agents/base.py
+++ b/bluesky_adaptive/agents/base.py
@@ -136,10 +136,12 @@ class Agent(ABC):
     and told to the agent by the ``tell`` method.
 
     Children of Agent should implment the following, through direct inheritence or mixin classes:
+    Experiment specific:
     - measurement_plan_name
     - measurement_plan_args
     - measurement_plan_kwargs
     - unpack_run
+    Agent specific:
     - tell
     - ask
     - report (optional)
@@ -251,9 +253,11 @@ class Agent(ABC):
                 kafka_producer_config=kafka_producer_config,
             )
         )
-        self.metadata["agent_name"] = self.agent_name = (
-            agent_name or f"{self.name}-{xp.generate_xkcdpassword(PASSWORD_LIST, numwords=2, delimiter='-')}"
+        self.instance_name = (
+            f"{self.name}-agent_name"
+            or f"{self.name}-{xp.generate_xkcdpassword(PASSWORD_LIST, numwords=2, delimiter='-')}"
         )
+        self.metadata["agent_name"] = self.instance_name
 
         self._ask_on_tell = ask_on_tell
         self._report_on_tell = report_on_tell

--- a/bluesky_adaptive/agents/simple.py
+++ b/bluesky_adaptive/agents/simple.py
@@ -1,0 +1,102 @@
+"""
+Module of mixins for agents that range from the sensible to the useless.
+These mixins act to fufill the abstract methods of blusky_adaptive.agents.Agent that are relevant to
+the decision making, and not the experimental specifics.
+    - tell
+    - ask
+    - report (optional)
+    - name (optional)
+
+Children will need to implement the following:
+Experiment specific:
+    - measurement_plan_name
+    - measurement_plan_args
+    - measurement_plan_kwargs
+    - unpack_run
+"""
+from abc import ABC
+from collections import defaultdict
+from logging import getLogger
+from typing import Generator, Sequence, Tuple, Union
+
+from numpy.typing import ArrayLike
+
+from bluesky_adaptive.agents.base import Agent
+
+logger = getLogger("bluesky_adaptive.agents")
+
+
+class SequentialAgentMixin(Agent, ABC):
+    """Agent Mixin to take a pre-defined sequence and walk through it on ``ask``.
+
+    Parameters
+    ----------
+    sequence : Sequence[Union[float, ArrayLike]]
+        Sequence of points to be queried
+    relative_bounds : Tuple[Union[float, ArrayLike]], optional
+        Relative bounds for the members of the sequence to follow, by default None
+
+    Attributes
+    ----------
+    independent_cache : list
+        List of the independent variables at each observed point
+    observable_cache : list
+        List of all observables corresponding to the points in the independent_cache
+    sequence : Sequence[Union[float, ArrayLike]]
+        Sequence of points to be queried
+    relative_bounds : Tuple[Union[float, ArrayLike]], optional
+        Relative bounds for the members of the sequence to follow, by default None
+    ask_count : int
+        Number of queries this agent has made
+    """
+
+    name = "sequential"
+
+    def __init__(
+        self,
+        *,
+        sequence: Sequence[Union[float, ArrayLike]],
+        relative_bounds: Tuple[Union[float, ArrayLike]] = None,
+        **kwargs,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.independent_cache = []
+        self.observable_cache = []
+        self.sequence = sequence
+        self.relative_bounds = relative_bounds
+        self.ask_count = 0
+        self._position_generator = self._create_position_generator()
+
+    def _create_position_generator(self) -> Generator:
+        """Yield points from sequence if within bounds"""
+        for point in self.sequence:
+            if self.relative_bounds:
+                condition = point <= self.relative_bounds[1] or point >= self.relative_bounds[0]
+                try:
+                    if condition:
+                        yield point
+                        continue
+                except ValueError:
+                    if condition.all():
+                        yield point
+                        continue
+            logger.warning(
+                f"Next point will be skipped.  {point} in sequence for {self.instance_name}, "
+                f"is out of bounds {self.relative_bounds}"
+            )
+
+    def tell(self, x, y) -> dict:
+        self.independent_cache.append(x)
+        self.observable_cache.append(y)
+        return dict(independent_variable=[x], observable=[y], cache_len=[len(self.independent_cache)])
+
+    def ask(self, batch_size: int = 1) -> Tuple[dict, Sequence]:
+        doc = defaultdict(list)
+        for _ in range(batch_size):
+            self.ask_count += 1
+            doc["proposal"].append(next(self._position_generator))
+        doc["ask_count"] = [self.ask_count]
+        return doc, doc["proposal"]
+
+    def report(self, **kwargs) -> dict:
+        return dict(percent_completion=[self.ask_count / len(self.sequence)])

--- a/bluesky_adaptive/tests/conftest.py
+++ b/bluesky_adaptive/tests/conftest.py
@@ -1,2 +1,22 @@
+# isort: skip_file
+import os
+
+import pytest
 from bluesky.tests.conftest import RE  # noqa
-from ophyd.tests.conftest import hw  # noqa
+from bluesky_kafka.tests.conftest import broker_authorization_config  # noqa
+from bluesky_kafka.tests.conftest import kafka_bootstrap_servers  # noqa
+from bluesky_kafka.tests.conftest import publisher_factory  # noqa
+from bluesky_kafka.tests.conftest import pytest_addoption  # noqa
+from bluesky_kafka.tests.conftest import temporary_topics  # noqa
+from bluesky_kafka.tests.conftest import consume_documents_from_kafka_until_first_stop_document  # noqa
+from pytest_docker import docker_ip, docker_services  # noqa
+
+
+@pytest.fixture(autouse=True, scope="session")
+def spin_docker(docker_ip, docker_services):  # noqa
+    return docker_ip
+
+
+@pytest.fixture(scope="session")
+def docker_compose_file(pytestconfig):
+    return os.path.join(str(pytestconfig.rootdir), "bluesky_adaptive", "tests", "docker-compose.yml")

--- a/bluesky_adaptive/tests/conftest.py
+++ b/bluesky_adaptive/tests/conftest.py
@@ -8,6 +8,7 @@ from bluesky_kafka.tests.conftest import publisher_factory  # noqa
 from bluesky_kafka.tests.conftest import pytest_addoption  # noqa
 from bluesky_kafka.tests.conftest import temporary_topics  # noqa
 from bluesky_kafka.tests.conftest import consume_documents_from_kafka_until_first_stop_document  # noqa
+from ophyd.tests.conftest import hw  # noqa
 
 
 # @pytest.fixture(autouse=True, scope="session")

--- a/bluesky_adaptive/tests/conftest.py
+++ b/bluesky_adaptive/tests/conftest.py
@@ -1,5 +1,4 @@
 # isort: skip_file
-import os
 
 import pytest
 from bluesky.tests.conftest import RE  # noqa
@@ -9,14 +8,18 @@ from bluesky_kafka.tests.conftest import publisher_factory  # noqa
 from bluesky_kafka.tests.conftest import pytest_addoption  # noqa
 from bluesky_kafka.tests.conftest import temporary_topics  # noqa
 from bluesky_kafka.tests.conftest import consume_documents_from_kafka_until_first_stop_document  # noqa
-from pytest_docker import docker_ip, docker_services  # noqa
 
 
-@pytest.fixture(autouse=True, scope="session")
-def spin_docker(docker_ip, docker_services):  # noqa
-    return docker_ip
+# @pytest.fixture(autouse=True, scope="session")
+# def spin_docker(docker_ip, docker_services):  # noqa
+#     return docker_ip
 
 
-@pytest.fixture(scope="session")
-def docker_compose_file(pytestconfig):
-    return os.path.join(str(pytestconfig.rootdir), "bluesky_adaptive", "tests", "docker-compose.yml")
+# @pytest.fixture(scope="session")
+# def docker_compose_file(pytestconfig):
+#     return os.path.join(str(pytestconfig.rootdir), "bluesky_adaptive", "tests", "docker-compose.yml")
+
+
+@pytest.fixture(scope="function")
+def tiled_profile():
+    return "testing_sandbox"

--- a/bluesky_adaptive/tests/docker-compose.yml
+++ b/bluesky_adaptive/tests/docker-compose.yml
@@ -1,0 +1,33 @@
+version: '2'
+
+services:
+  zookeeper:
+    image: 'docker.io/bitnami/zookeeper:latest'
+    ports:
+      - '2181:2181'
+    volumes:
+      - 'zookeeper_data:/bitnami'
+    environment:
+      - ALLOW_ANONYMOUS_LOGIN=yes
+  kafka:
+    image: 'docker.io/bitnami/kafka:latest'
+    ports:
+      - '9092:9092'
+      - '29092:29092'
+    volumes:
+      - 'kafka_data:/bitnami'
+    environment:
+      - KAFKA_CFG_ZOOKEEPER_CONNECT=zookeeper:2181
+      - ALLOW_PLAINTEXT_LISTENER=yes
+      - KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      - KAFKA_CFG_LISTENERS=PLAINTEXT://:29092,PLAINTEXT_HOST://:9092
+      - KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://kafka:29092,PLAINTEXT_HOST://localhost:9092
+      - KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE=false
+    depends_on:
+      - zookeeper
+
+volumes:
+  zookeeper_data:
+    driver: local
+  kafka_data:
+    driver: local

--- a/bluesky_adaptive/tests/docker-compose.yml
+++ b/bluesky_adaptive/tests/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '3.2'
 
 services:
   zookeeper:
@@ -9,6 +9,7 @@ services:
       - 'zookeeper_data:/bitnami'
     environment:
       - ALLOW_ANONYMOUS_LOGIN=yes
+
   kafka:
     image: 'docker.io/bitnami/kafka:latest'
     ports:
@@ -25,6 +26,13 @@ services:
       - KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE=false
     depends_on:
       - zookeeper
+
+  mongodb:
+    image: 'docker.io/library/mongo:latest'
+    ports:
+      - '27017:27017'
+    volumes:
+      - '/tmp/databroker:/data/db'
 
 volumes:
   zookeeper_data:

--- a/bluesky_adaptive/tests/docker-compose.yml
+++ b/bluesky_adaptive/tests/docker-compose.yml
@@ -9,6 +9,8 @@ services:
       - 'zookeeper_data:/bitnami'
     environment:
       - ALLOW_ANONYMOUS_LOGIN=yes
+    networks:
+      - re_manager
 
   kafka:
     image: 'docker.io/bitnami/kafka:latest'
@@ -26,6 +28,8 @@ services:
       - KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE=false
     depends_on:
       - zookeeper
+    networks:
+      - re_manager
 
   mongodb:
     image: 'docker.io/library/mongo:latest'
@@ -33,6 +37,37 @@ services:
       - '27017:27017'
     volumes:
       - '/tmp/databroker:/data/db'
+
+  redis:
+    image: redis:6.2-alpine
+    ports:
+      - 6379:6379
+    networks:
+      - re_manager
+  qserver:
+    image: qserver:latest
+    environment:
+      - REDIS_ADDR=redis:6379
+    networks:
+      - re_manager
+    ports:
+      - 60615:60615
+    depends_on:
+      - redis
+
+  httpserver:
+    image: http-server:latest
+    ports:
+      - 60610:60610
+    environment:
+      - QSERVER_ZMQ_CONTROL_ADDRESS=tcp://qserver:60615
+      - QSERVER_ZMQ_INFO_ADDRESS=tcp://qserver:60625
+    networks:
+      - re_manager
+
+networks:
+  re_manager:
+    driver: bridge
 
 volumes:
   zookeeper_data:

--- a/bluesky_adaptive/tests/test_agents.py
+++ b/bluesky_adaptive/tests/test_agents.py
@@ -1,0 +1,78 @@
+from typing import Sequence, Tuple, Union
+
+from bluesky_live.run_builder import RunBuilder
+from databroker.client import BlueskyRun
+from numpy.typing import ArrayLike
+from tiled.client import from_profile
+
+from bluesky_adaptive.agents.base import Agent
+
+
+class TestCommunicationAgent(Agent):
+    measurement_plan_name = "test_plan"
+
+    def __init__(
+        self, pub_topic, sub_topic, kafka_bootstrap_servers, broker_authorization_config, tiled_profile, **kwargs
+    ):
+        super().__init__(
+            kafka_group_id="test.communication.group",
+            kafka_bootstrap_servers=kafka_bootstrap_servers,
+            kafka_producer_config=broker_authorization_config,
+            kafka_consumer_config={"auto.offset.reset": "latest"},
+            publisher_topic=pub_topic,
+            subscripion_topics=[sub_topic],
+            data_profile_name=tiled_profile,
+            agent_profile_name=tiled_profile,
+            qserver_host=None,
+            qserver_api_key="SECRET",
+            **kwargs,
+        )
+
+    def measurement_plan_args(point) -> list:
+        return list()
+
+    def measurement_plan_kwargs(point) -> dict:
+        return dict()
+
+    def unpack_run(run: BlueskyRun) -> Tuple[Union[float, ArrayLike], Union[float, ArrayLike]]:
+        return 0, 0
+
+    def report(self, report_number: int = 0) -> dict:
+        return dict(agent_name=self.instance_name, report=f"report_{report_number}")
+
+    def ask(self, batch_size: int = 1) -> Tuple[dict, Sequence]:
+        return (dict(agent_name=self.instance_name, report=f"ask_{batch_size}"), [0 for _ in range(batch_size)])
+
+    def tell(self, x, y) -> dict:
+        return dict(x=x, y=y)
+
+    def start(self):
+        """Start without kafka consumer start"""
+        self.builder = RunBuilder(metadata=self.metadata)
+        self.agent_catalog.v1.insert("start", self.builder._cache.start_doc)
+
+
+def test_agent_doc_stream(temporary_topics, kafka_bootstrap_servers, broker_authorization_config, tiled_profile):
+    """Test the ability to write agent actions as bluesky run and readback in tiled"""
+    cat = from_profile(tiled_profile)
+
+    with temporary_topics(topics=["test.publisher", "test.subscriber"]) as (pub, sub):
+        agent = TestCommunicationAgent(
+            pub, sub, kafka_bootstrap_servers, broker_authorization_config, tiled_profile
+        )
+        agent.start()
+        doc, _ = agent.ask(1)
+        ask_uid = agent._write_event("ask", doc)
+        doc = agent.tell(0, 0)
+        _ = agent._write_event("tell", doc)
+        doc = agent.report()
+        _ = agent._write_event("report", doc)
+
+        documents = list(cat[-1].documents())
+        assert documents[0][0] == "start"
+        assert documents[1][0] == "descriptor"
+        assert documents[2][0] == "event_page"
+        assert "report" in cat[-1].metadata["summary"]["stream_names"]
+        assert "ask" in cat[-1].metadata["summary"]["stream_names"]
+        assert "tell" in cat[-1].metadata["summary"]["stream_names"]
+        assert isinstance(ask_uid, list)

--- a/bluesky_adaptive/tests/test_agents.py
+++ b/bluesky_adaptive/tests/test_agents.py
@@ -156,10 +156,10 @@ def test_feedback_to_queue(
                 key=f"{sub_topic}.key",
                 flush_on_stop_doc=True,
             )
-            start_time = ttime.time()
+            start_time = ttime.monotonic()
 
             def until_time():
-                if ttime.time() > start_time + sec:
+                if ttime.monotonic() > start_time + sec:
                     return False
                 else:
                     fake_publisher("start", builder._cache.start_doc)

--- a/bluesky_adaptive/tests/test_agents.py
+++ b/bluesky_adaptive/tests/test_agents.py
@@ -9,6 +9,8 @@ from tiled.client import from_profile
 from bluesky_adaptive.agents.base import Agent
 from bluesky_adaptive.agents.simple import SequentialAgentBase
 
+from bluesky_queueserver_api.http import REManagerAPI
+
 
 class TestCommunicationAgent(Agent):
     measurement_plan_name = "agent_driven_nap"
@@ -17,6 +19,9 @@ class TestCommunicationAgent(Agent):
     def __init__(
         self, pub_topic, sub_topic, kafka_bootstrap_servers, broker_authorization_config, tiled_profile, **kwargs
     ):
+        qs = REManagerAPI(http_server_uri=None)
+        qs.set_authorization_key(api_key="SECRET")
+
         super().__init__(
             kafka_group_id="test.communication.group",
             kafka_bootstrap_servers=kafka_bootstrap_servers,
@@ -26,8 +31,7 @@ class TestCommunicationAgent(Agent):
             subscripion_topics=[sub_topic],
             data_profile_name=tiled_profile,
             agent_profile_name=tiled_profile,
-            qserver_host=None,
-            qserver_api_key="SECRET",
+            qserver=qs,
             **kwargs,
         )
         self.count = 0
@@ -180,6 +184,9 @@ class TestSequentialAgent(SequentialAgentBase):
     def __init__(
         self, pub_topic, sub_topic, kafka_bootstrap_servers, broker_authorization_config, tiled_profile, **kwargs
     ):
+        qs = REManagerAPI(http_server_uri=None)
+        qs.set_authorization_key(api_key="SECRET")
+
         super().__init__(
             kafka_group_id="test.communication.group",
             kafka_bootstrap_servers=kafka_bootstrap_servers,
@@ -189,8 +196,7 @@ class TestSequentialAgent(SequentialAgentBase):
             subscripion_topics=[sub_topic],
             data_profile_name=tiled_profile,
             agent_profile_name=tiled_profile,
-            qserver_host=None,
-            qserver_api_key="SECRET",
+            qserver=qs,
             **kwargs,
         )
         self.count = 0

--- a/bluesky_adaptive/tests/test_agents.py
+++ b/bluesky_adaptive/tests/test_agents.py
@@ -12,6 +12,7 @@ from bluesky_adaptive.agents.simple import SequentialAgentBase
 
 class TestCommunicationAgent(Agent):
     measurement_plan_name = "agent_driven_nap"
+    instance_name = 'bob'
 
     def __init__(
         self, pub_topic, sub_topic, kafka_bootstrap_servers, broker_authorization_config, tiled_profile, **kwargs

--- a/bluesky_adaptive/tests/test_kafka.py
+++ b/bluesky_adaptive/tests/test_kafka.py
@@ -1,3 +1,4 @@
+import time as ttime
 from bluesky_kafka import BlueskyConsumer, Publisher, RemoteDispatcher
 
 from bluesky_adaptive.agents.base import AgentConsumer
@@ -143,8 +144,12 @@ def test_agent_consumer(kafka_bootstrap_servers, broker_authorization_config, te
             agent=BarebonesAgent(),
         )
         consumer.subscribe(process_document)
+        start_time = ttime.time()
+        sec = 5
 
         def until_len():
+            if ttime.time() > start_time + sec:
+                return False
             if len(consumed_documents) >= 2:
                 return False
             else:
@@ -203,8 +208,12 @@ def test_agent_interaction(kafka_bootstrap_servers, broker_authorization_config,
         agent = DummyAgent(topics)
         agent.consumer.subscribe(process_document)
         agent.consumer.subscribe(agent.tell)
+        start_time = ttime.time()
+        sec = 5
 
         def until_len():
+            if ttime.time() > start_time + sec:
+                return False
             if len(consumed_documents) >= 2:
                 return False
             else:

--- a/bluesky_adaptive/tests/test_kafka.py
+++ b/bluesky_adaptive/tests/test_kafka.py
@@ -144,11 +144,11 @@ def test_agent_consumer(kafka_bootstrap_servers, broker_authorization_config, te
             agent=BarebonesAgent(),
         )
         consumer.subscribe(process_document)
-        start_time = ttime.time()
+        start_time = ttime.monotonic()
         sec = 5
 
         def until_len():
-            if ttime.time() > start_time + sec:
+            if ttime.monotonic() > start_time + sec:
                 return False
             if len(consumed_documents) >= 2:
                 return False
@@ -208,11 +208,11 @@ def test_agent_interaction(kafka_bootstrap_servers, broker_authorization_config,
         agent = DummyAgent(topics)
         agent.consumer.subscribe(process_document)
         agent.consumer.subscribe(agent.tell)
-        start_time = ttime.time()
+        start_time = ttime.monotonic()
         sec = 5
 
         def until_len():
-            if ttime.time() > start_time + sec:
+            if ttime.monotonic() > start_time + sec:
                 return False
             if len(consumed_documents) >= 2:
                 return False

--- a/bluesky_adaptive/tests/test_kafka.py
+++ b/bluesky_adaptive/tests/test_kafka.py
@@ -165,7 +165,7 @@ def test_agent_consumer(kafka_bootstrap_servers, broker_authorization_config, te
         assert len(consumed_docs) == 2
 
 
-def test_agent_interaction(kafka_bootstrap_servers, broker_authorization_config, temporary_topics):
+def test_agent_interaction(kafka_bootstrap_servers, broker_authorization_config, temporary_topics, caplog):
     class DummyAgent:
         agent_name = "dummy_agent"
 
@@ -215,6 +215,7 @@ def test_agent_interaction(kafka_bootstrap_servers, broker_authorization_config,
         )
 
         publisher("dummy_agent", dict(action="increase", args=[], kwargs={}))
+        publisher("dummy_agent", dict(action="decrease", args=[], kwargs={}))
         publisher("start", {"uid": "123"})
         publisher("stop", {"start": "123"})
 
@@ -224,3 +225,4 @@ def test_agent_interaction(kafka_bootstrap_servers, broker_authorization_config,
         # Only bluesky documents get consumed by the callbacks
         assert len(consumed_docs) == 2
         assert len(agent.cache) == 2
+        assert "Unavailable action sent to agent" in caplog.text

--- a/bluesky_adaptive/tests/test_kafka.py
+++ b/bluesky_adaptive/tests/test_kafka.py
@@ -1,0 +1,226 @@
+from bluesky_kafka import BlueskyConsumer, Publisher, RemoteDispatcher
+
+from bluesky_adaptive.agents.base import AgentConsumer
+
+
+def test_pubsub_smoke(temporary_topics, publisher_factory, consume_documents_from_kafka_until_first_stop_document):
+
+    with temporary_topics(topics=["test.publisher.and.subscriber"]) as (topic,):
+        bluesky_publisher = publisher_factory(
+            topic=topic,
+            key=f"{topic}.key",
+            flush_on_stop_doc=True,
+        )
+        bluesky_publisher("start", {"uid": "123"})
+        bluesky_publisher("stop", {"start": "123"})
+        consumed_bluesky_documents = consume_documents_from_kafka_until_first_stop_document(kafka_topic=topic)
+        assert len(consumed_bluesky_documents) == 2
+
+
+def test_pubsub_smoke2(
+    temporary_topics,
+    broker_authorization_config,
+    kafka_bootstrap_servers,
+    consume_documents_from_kafka_until_first_stop_document,
+):
+
+    with temporary_topics(topics=["test.publisher.and.subscriber"]) as (topic,):
+        publisher = Publisher(
+            topic=topic,
+            bootstrap_servers=kafka_bootstrap_servers,
+            producer_config=broker_authorization_config,
+            key=f"{topic}.key",
+        )
+        publisher("start", {"uid": "123"})
+        publisher("stop", {"start": "123"})
+        consumed_bluesky_documents = consume_documents_from_kafka_until_first_stop_document(kafka_topic=topic)
+        assert len(consumed_bluesky_documents) == 2
+
+
+def test_pubsub_smoke3(
+    temporary_topics,
+    broker_authorization_config,
+    kafka_bootstrap_servers,
+):
+    """Testing locally scoped consumers"""
+
+    def consume_until_len(kafka_topic, length):
+        consumed_documents = []
+
+        def process_document(consumer, topic, name, document):
+            consumed_documents.append((name, document))
+
+        consumer = BlueskyConsumer(
+            topics=[kafka_topic],
+            bootstrap_servers=kafka_bootstrap_servers,
+            group_id=f"{kafka_topic}.consumer.group",
+            consumer_config={"auto.offset.reset": "earliest"},
+            process_document=process_document,
+        )
+
+        def until_len():
+            if len(consumed_documents) >= length:
+                return False
+            else:
+                return True
+
+        consumer.start(continue_polling=until_len)
+        return consumed_documents
+
+    with temporary_topics(topics=["test.publisher.and.subscriber"]) as (topic,):
+        publisher = Publisher(
+            topic=topic,
+            bootstrap_servers=kafka_bootstrap_servers,
+            producer_config=broker_authorization_config,
+            key=f"{topic}.key",
+        )
+        publisher("start", {"uid": "123"})
+        publisher("stop", {"start": "123"})
+        cache = consume_until_len(kafka_topic=topic, length=1)
+        assert len(cache) == 1
+
+
+def test_dispatcher(kafka_bootstrap_servers, broker_authorization_config, temporary_topics):
+    """Test agent collection of documents and increment by command."""
+
+    def fixed_consumer(topics):
+        """Collects the first 10 documents and returns the agent"""
+        consumed_documents = []
+
+        def process_document(name, document):
+            consumed_documents.append((name, document))
+
+        dispatcher = RemoteDispatcher(
+            topics,
+            bootstrap_servers=kafka_bootstrap_servers,
+            group_id="dummy.agent.group",
+            consumer_config={"auto.offset.reset": "earliest"},
+        )
+        dispatcher.subscribe(process_document)
+
+        def until_len():
+            if len(consumed_documents) >= 2:
+                return False
+            else:
+                return True
+
+        dispatcher.start(continue_polling=until_len)
+        return consumed_documents
+
+    with temporary_topics(topics=["test.publisher.and.subscriber"]) as (topic,):
+        publisher = Publisher(
+            topic=topic,
+            bootstrap_servers=kafka_bootstrap_servers,
+            producer_config=broker_authorization_config,
+            key=f"{topic}.key",
+        )
+        publisher("start", {"uid": "123"})
+        publisher("stop", {"start": "123"})
+        docs = fixed_consumer([topic])
+        assert len(docs) == 2
+
+
+def test_agent_consumer(kafka_bootstrap_servers, broker_authorization_config, temporary_topics):
+    """Test agent collection of documents and increment by command."""
+
+    class Foo:
+        agent_name = ""
+
+    def fixed_consumer(topics):
+        """Collects the first 10 documents and returns the agent"""
+        consumed_documents = []
+
+        def process_document(name, document):
+            consumed_documents.append((name, document))
+
+        consumer = AgentConsumer(
+            topics=topics,
+            bootstrap_servers=kafka_bootstrap_servers,
+            group_id="dummy.agent.group",
+            consumer_config={"auto.offset.reset": "earliest"},
+            agent=Foo(),
+        )
+        consumer.subscribe(process_document)
+
+        def until_len():
+            if len(consumed_documents) >= 2:
+                return False
+            else:
+                return True
+
+        consumer.start(continue_polling=until_len)
+        return consumed_documents
+
+    with temporary_topics(topics=["test.publisher.and.subscriber"]) as (topic,):
+        publisher = Publisher(
+            topic=topic,
+            bootstrap_servers=kafka_bootstrap_servers,
+            producer_config=broker_authorization_config,
+            key=f"{topic}.key",
+        )
+        publisher("start", {"uid": "123"})
+        publisher("stop", {"start": "123"})
+        consumed_docs = fixed_consumer(topics=[topic])
+
+        assert len(consumed_docs) == 2
+
+
+def test_agent_interaction(kafka_bootstrap_servers, broker_authorization_config, temporary_topics):
+    class DummyAgent:
+        agent_name = "dummy_agent"
+
+        def __init__(self, topics):
+            self.counter = 0
+            self.consumer = AgentConsumer(
+                topics=topics,
+                bootstrap_servers=kafka_bootstrap_servers,
+                group_id="dummy.agent.group",
+                agent=self,
+                consumer_config={"auto.offset.reset": "earliest"},
+            )
+            self.cache = []
+
+        def increase(self):
+            self.counter += 1
+
+        def tell(self, name, doc):
+            self.cache.append((name, doc))
+
+    def fixed_consumer(topics):
+        """Collects the first 10 documents and returns the agent"""
+        consumed_documents = []
+
+        def process_document(name, document):
+            consumed_documents.append((name, document))
+
+        agent = DummyAgent(topics)
+        agent.consumer.subscribe(process_document)
+        agent.consumer.subscribe(agent.tell)
+
+        def until_len():
+            if len(consumed_documents) >= 2:
+                return False
+            else:
+                return True
+
+        agent.consumer.start(continue_polling=until_len)
+        return consumed_documents, agent
+
+    with temporary_topics(topics=["test.publisher.and.subscriber"]) as (topic,):
+        publisher = Publisher(
+            topic=topic,
+            bootstrap_servers=kafka_bootstrap_servers,
+            producer_config=broker_authorization_config,
+            key=f"{topic}.key",
+        )
+
+        publisher("dummy_agent", dict(action="increase", args=[], kwargs={}))
+        publisher("start", {"uid": "123"})
+        publisher("stop", {"start": "123"})
+
+        consumed_docs, agent = fixed_consumer(topics=[topic])
+
+        assert agent.counter == 1
+        # Only bluesky documents get consumed by the callbacks
+        assert len(consumed_docs) == 2
+        assert len(agent.cache) == 2

--- a/bluesky_adaptive/tests/test_kafka.py
+++ b/bluesky_adaptive/tests/test_kafka.py
@@ -127,7 +127,7 @@ def test_agent_consumer(kafka_bootstrap_servers, broker_authorization_config, te
     class BarebonesAgent:
         """Agent with only necessary attributes to test non-interactive AgentConsumer"""
 
-        agent_name = ""
+        agent_name = instance_name = ""
 
     def fixed_consumer(topics):
         """Collects the first 10 documents and returns the agent"""
@@ -179,7 +179,7 @@ def test_agent_interaction(kafka_bootstrap_servers, broker_authorization_config,
         """Simple agent to test the interactivity of an Agent consumer by using a tell to cache documents
         and an internal counter that can be triggered by kafka mesages"""
 
-        agent_name = "dummy_agent"
+        agent_name = instance_name = "dummy_agent"
 
         def __init__(self, topics):
             self.counter = 0

--- a/bluesky_adaptive/tests/tiled_client_config.yml
+++ b/bluesky_adaptive/tests/tiled_client_config.yml
@@ -1,0 +1,9 @@
+testing_sandbox:
+  direct:
+    authentication:
+      allow_anonymous_access: true
+    trees:
+      - tree: databroker.mongo_normalized:Tree.from_uri
+        path: /
+        args:
+          uri: mongodb://localhost:27017/testing_sandbox

--- a/docker/README.md
+++ b/docker/README.md
@@ -11,3 +11,4 @@ cd ../http-server
 docker build -t http-server:latest .
 cd ../
 docker-compose up
+```

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,13 @@
+# Docker Notes
+
+The following docker files are split up for the queue-server and http-server for testing. The docker compose here will spin them up together along with a networked redis server. They are bare bones and will lack the full functionality of a collection profile, but should be useful for simple testing.
+
+## To run the containers:
+```bash
+cd docker/queue-server
+docker build -t qserver:latest .
+# The http-server image is based on the queue-server image so goes second.
+cd ../http-server
+docker build -t http-server:latest .
+cd ../
+docker-compose up

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,30 @@
+version: '3.2'
+
+services:
+  redis:
+    image: redis:6.2-alpine
+    ports:
+      - 6379:6379
+    networks:
+      - qserver_network
+  qserver:
+    image: qserver:latest
+    environment:
+      - REDIS_ADDR=redis:6379
+    networks:
+      - qserver_network
+    ports:
+      - 60615:60615
+  httpserver:
+    image: http-server:latest
+    ports:
+      - 60610:60610
+    environment:
+      - QSERVER_ZMQ_CONTROL_ADDRESS=tcp://qserver:60615
+      - QSERVER_ZMQ_INFO_ADDRESS=tcp://qserver:60625
+    networks:
+      - qserver_network
+
+networks:
+  qserver_network:
+    driver: bridge

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -25,6 +25,34 @@ services:
     networks:
       - qserver_network
 
+  zookeeper:
+    image: docker.io/confluentinc/cp-zookeeper:7.3.0
+    container_name: zookeeper
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+    networks:
+      - qserver_network
+
+  broker:
+    image: docker.io/confluentinc/cp-kafka:7.3.0
+    container_name: broker
+    ports:
+    # To learn about configuring Kafka for access across networks see
+    # https://www.confluent.io/blog/kafka-client-cannot-connect-to-broker-on-aws-on-docker-etc/
+      - "9092:9092"
+    depends_on:
+      - zookeeper
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: 'zookeeper:2181'
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_INTERNAL:PLAINTEXT
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092,PLAINTEXT_INTERNAL://broker:29092
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+
+    networks:
+      - qserver_network
 networks:
-  qserver_network:
-    driver: bridge
+  qserver_network: {}

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.2'
 
 services:
   redis:
-    image: redis:6.2-alpine
+    image: docker.io/redis:6.2-alpine
     ports:
       - 6379:6379
     networks:

--- a/docker/http-server/Dockerfile
+++ b/docker/http-server/Dockerfile
@@ -1,0 +1,12 @@
+# docker build -t http-server:latest .
+FROM  qserver:latest
+
+RUN pip3 install bluesky-httpserver
+
+ENV QSERVER_HTTP_SERVER_SINGLE_USER_API_KEY="SECRET"
+#ENV QSERVER_HTTP_SERVER_ALLOW_ANONYMOUS_ACCESS=1
+ENV QSERVER_ZMQ_CONTROL_ADDRESS=tcp://qserver:60615
+ENV QSERVER_ZMQ_INFO_ADDRESS=tcp://qserver:60625
+EXPOSE 60610
+
+CMD uvicorn bluesky_httpserver.server:app --host 0.0.0.0 --port 60610

--- a/docker/queue-server/16-plans.py
+++ b/docker/queue-server/16-plans.py
@@ -1,0 +1,15 @@
+# Plans for testing.
+# These will get populated into the run manager persmissions when the environemnts is opened.
+# Named 16-plans because qserver ships with a 00-ophyd, 15-plans, 99-custom.
+
+import bluesky.preprocessors as bpp
+from bluesky import plan_stubs as bps
+
+
+@bpp.run_decorator()
+def agent_driven_nap(delay: float, *, delay_kwarg: float = 0, md=None):
+    """Ensuring we can auto add 'agent_' plans and use args/kwargs"""
+    if delay_kwarg:
+        yield from bps.sleep(delay_kwarg)
+    else:
+        yield from bps.sleep(delay)

--- a/docker/queue-server/Dockerfile
+++ b/docker/queue-server/Dockerfile
@@ -14,6 +14,9 @@ RUN python3.9 -m ensurepip --upgrade
 
 RUN pip3 install bluesky-queueserver
 
+# Add custom plans
+COPY 16-plans.py /usr/local/lib/python3.9/site-packages/bluesky_queueserver/profile_collection_sim/
+
 ENV REDIS_ADDR=redis:6379
 ENV QSERVER_ZMQ_CONTROL_ADDRESS=tcp://127.0.0.1:60615
 ENV QSERVER_ZMQ_INFO_ADDRESS=tcp://127.0.0.1:60625

--- a/docker/queue-server/Dockerfile
+++ b/docker/queue-server/Dockerfile
@@ -1,0 +1,21 @@
+# docker build -t qserver:latest .
+FROM  fedora
+# Lock in a python version because of some backward compatability issues
+RUN dnf update -y \
+    && dnf install -y \
+    python3.9 \
+    g++ \
+    gcc \
+    git \
+    && dnf clean all
+
+RUN python3.9 -m ensurepip --upgrade
+
+
+RUN pip3 install bluesky-queueserver
+
+ENV REDIS_ADDR=redis:6379
+ENV QSERVER_ZMQ_CONTROL_ADDRESS=tcp://127.0.0.1:60615
+ENV QSERVER_ZMQ_INFO_ADDRESS=tcp://127.0.0.1:60625
+
+CMD start-re-manager --redis-addr ${REDIS_ADDR}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -24,6 +24,7 @@
 
 # -- General configuration ------------------------------------------------
 import sphinx
+
 # If your documentation needs a minimal Sphinx version, state it here.
 #
 # needs_sphinx = '1.0'
@@ -32,17 +33,17 @@ import sphinx
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    'sphinx.ext.autodoc',
-    'sphinx.ext.autosummary',
-    'sphinx.ext.githubpages',
-    'sphinx.ext.intersphinx',
-    'sphinx.ext.mathjax',
-    'sphinx.ext.viewcode',
-    'IPython.sphinxext.ipython_directive',
-    'IPython.sphinxext.ipython_console_highlighting',
-    'matplotlib.sphinxext.plot_directive',
-    'numpydoc',
-    'sphinx_copybutton',
+    "sphinx.ext.autodoc",
+    "sphinx.ext.autosummary",
+    "sphinx.ext.githubpages",
+    "sphinx.ext.intersphinx",
+    "sphinx.ext.mathjax",
+    "sphinx.ext.viewcode",
+    "IPython.sphinxext.ipython_directive",
+    "IPython.sphinxext.ipython_console_highlighting",
+    "matplotlib.sphinxext.plot_directive",
+    "numpydoc",
+    "sphinx_copybutton",
 ]
 
 # Configuration options for plot_directive. See:
@@ -55,27 +56,28 @@ autosummary_generate = True
 numpydoc_show_class_members = False
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+templates_path = ["_templates"]
 
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:
 #
 # source_suffix = ['.rst', '.md']
-source_suffix = '.rst'
+source_suffix = ".rst"
 
 # The master toctree document.
-master_doc = 'index'
+master_doc = "index"
 
 # General information about the project.
-project = 'bluesky-adaptive'
-copyright = '2020, NSLS-II'
-author = 'NSLS-II'
+project = "bluesky-adaptive"
+copyright = "2020, NSLS-II"
+author = "NSLS-II"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
 # built documents.
 #
 import bluesky_adaptive
+
 # The short X.Y version.
 version = bluesky_adaptive.__version__
 # The full version, including alpha/beta/rc tags.
@@ -86,7 +88,7 @@ release = bluesky_adaptive.__version__
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
@@ -94,7 +96,7 @@ language = None
 exclude_patterns = []
 
 # The name of the Pygments (syntax highlighting) style to use.
-pygments_style = 'sphinx'
+pygments_style = "sphinx"
 
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = False
@@ -105,8 +107,9 @@ todo_include_todos = False
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'sphinx_rtd_theme'
+html_theme = "sphinx_rtd_theme"
 import sphinx_rtd_theme
+
 html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 # Theme options are theme-specific and customize the look and feel of a theme
@@ -118,7 +121,7 @@ html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = ["_static"]
 
 # Custom sidebar templates, must be a dictionary that maps document names
 # to template names.
@@ -126,9 +129,9 @@ html_static_path = ['_static']
 # This is required for the alabaster theme
 # refs: http://alabaster.readthedocs.io/en/latest/installation.html#sidebars
 html_sidebars = {
-    '**': [
-        'relations.html',  # needs 'show_related': True theme option to display
-        'searchbox.html',
+    "**": [
+        "relations.html",  # needs 'show_related': True theme option to display
+        "searchbox.html",
     ]
 }
 
@@ -136,7 +139,7 @@ html_sidebars = {
 # -- Options for HTMLHelp output ------------------------------------------
 
 # Output file base name for HTML help builder.
-htmlhelp_basename = 'bluesky-adaptive'
+htmlhelp_basename = "bluesky-adaptive"
 
 
 # -- Options for LaTeX output ---------------------------------------------
@@ -145,15 +148,12 @@ latex_elements = {
     # The paper size ('letterpaper' or 'a4paper').
     #
     # 'papersize': 'letterpaper',
-
     # The font size ('10pt', '11pt' or '12pt').
     #
     # 'pointsize': '10pt',
-
     # Additional stuff for the LaTeX preamble.
     #
     # 'preamble': '',
-
     # Latex figure (float) alignment
     #
     # 'figure_align': 'htbp',
@@ -163,8 +163,7 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, 'bluesky-adaptive.tex', 'bluesky-adaptive Documentation',
-     'Contributors', 'manual'),
+    (master_doc, "bluesky-adaptive.tex", "bluesky-adaptive Documentation", "Contributors", "manual"),
 ]
 
 
@@ -172,10 +171,7 @@ latex_documents = [
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
-man_pages = [
-    (master_doc, 'bluesky-adaptive', 'bluesky-adaptive Documentation',
-     [author], 1)
-]
+man_pages = [(master_doc, "bluesky-adaptive", "bluesky-adaptive Documentation", [author], 1)]
 
 
 # -- Options for Texinfo output -------------------------------------------
@@ -184,24 +180,30 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-    (master_doc, 'bluesky-adaptive', 'bluesky-adaptive Documentation',
-     author, 'bluesky-adaptive', 'Tools for writing adaptive plans',
-     'Miscellaneous'),
+    (
+        master_doc,
+        "bluesky-adaptive",
+        "bluesky-adaptive Documentation",
+        author,
+        "bluesky-adaptive",
+        "Tools for writing adaptive plans",
+        "Miscellaneous",
+    ),
 ]
 
-default_role = 'obj'
+default_role = "obj"
 
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
-    'python': ('https://docs.python.org/3/', None),
-    'numpy': ('https://numpy.org/doc/stable/', None),
-    'scipy': ('https://docs.scipy.org/doc/scipy/reference/', None),
-    'pandas': ('https://pandas.pydata.org/pandas-docs/stable', None),
-    'matplotlib': ('https://matplotlib.org', None),
-    'bluesky': ('https://blueskyproject.io/bluesky/', None),
-    'ophyd': ('https://blueskyproject.io/ophyd/', None),
-    'event-model': ('https://blueskyproject.io/event-model/', None),
+    "python": ("https://docs.python.org/3/", None),
+    "numpy": ("https://numpy.org/doc/stable/", None),
+    "scipy": ("https://docs.scipy.org/doc/scipy/reference/", None),
+    "pandas": ("https://pandas.pydata.org/pandas-docs/stable", None),
+    "matplotlib": ("https://matplotlib.org", None),
+    "bluesky": ("https://blueskyproject.io/bluesky/", None),
+    "ophyd": ("https://blueskyproject.io/ophyd/", None),
+    "event-model": ("https://blueskyproject.io/event-model/", None),
 }
 
 # nitpicky = sphinx.version_info >= (3,)

--- a/docs/source/distributed.rst
+++ b/docs/source/distributed.rst
@@ -58,6 +58,14 @@ as abstract in the base Agent.
 
 .. code-block:: python
 
+
+    from bluesky_queueserver_api.http import REManagerAPI
+    import uuid
+    from typing import Sequence, Tuple, Union
+
+    import nslsii.kafka_utils
+    from numpy.typing import ArrayLike
+
     class SequentialAgentBase(Agent, ABC):
         """Agent Mixin to take a pre-defined sequence and walk through it on ``ask``.
 
@@ -187,7 +195,7 @@ as abstract in the base Agent.
             )
 
 
-    class CMSSequentialAgent(SequentialAgentBase, CMSBaseAgent):
+    class CMSSequentialAgent(CMSBaseAgent, SequentialAgentBase):
         def __init__(
             self,
             *,

--- a/docs/source/distributed.rst
+++ b/docs/source/distributed.rst
@@ -1,0 +1,199 @@
+.. _distributed:
+
+Distributed Agents
+==================
+
+This section descibes how to work with agents whos distributed agents using the
+queueserver. It is particularly pertinent when:
+
+- The agent is slower than the measurement
+- lock-step behvior is not desired
+- Multiple agents should run simultaneously
+- Human's and agents are meant to collaborate
+
+
+These agents depend on Kafka for communication. Each time they see a stop document,
+they check if the run is relevant to their decision making (*via* ``trigger_condition``),
+then load the Bluesky Run through Tiled.
+The run is then processed, and unpacked into the relevant independent and dependent variables
+(*via* ``unpack_run``).
+The agent then call's its ``tell`` method on the independent and dependent variables. In this case
+The ``unpack_run`` might pull out some motor coordinates, and a 2-d detector image; and the ``tell``
+might cache those as relative coordinates and some post-processing of the image.
+
+Agents should subclass the `blusky_adaptive.agents.base.agent` and are responsible for implementing the
+following.
+
+Experiment specific
+-------------------
+
+.. autoproperty:: bluesky_adaptive.agents.base.Agent.measurement_plan_name
+.. automethod:: bluesky_adaptive.agents.base.Agent.measurement_plan_args
+.. automethod:: bluesky_adaptive.agents.base.Agent.measurement_plan_kwargs
+
+
+Agent 'brains' specific
+-----------------------
+
+
+.. automethod:: bluesky_adaptive.agents.base.Agent.ask
+.. automethod:: bluesky_adaptive.agents.base.Agent.report
+.. autoproperty:: bluesky_adaptive.agents.base.Agent.name
+
+The complete base class is given as follows:
+
+.. autoclass:: bluesky_adaptive.agents.base.Agent
+
+
+Examples
+--------
+
+The following example creates a simple hypothetical agent that only follows a sequence of
+predetermined points. While not clever, it shows the underlying mechanics.
+It copies some importable code from `bluesky_adaptive.agents.simple`.
+In this case the user need only construct `CMSBaseAgent` for some CMS specific values,
+and combine the `SequentialAgent` and `CMSBaseAgent`.
+This can be done through direct inheritence or mixins, as all necessary methods are declared
+as abstract in the base Agent.
+
+.. code-block:: python
+
+    class SequentialAgentBase(Agent, ABC):
+        """Agent Mixin to take a pre-defined sequence and walk through it on ``ask``.
+
+        Parameters
+        ----------
+        sequence : Sequence[Union[float, ArrayLike]]
+            Sequence of points to be queried
+        relative_bounds : Tuple[Union[float, ArrayLike]], optional
+            Relative bounds for the members of the sequence to follow, by default None
+
+        Attributes
+        ----------
+        independent_cache : list
+            List of the independent variables at each observed point
+        observable_cache : list
+            List of all observables corresponding to the points in the independent_cache
+        sequence : Sequence[Union[float, ArrayLike]]
+            Sequence of points to be queried
+        relative_bounds : Tuple[Union[float, ArrayLike]], optional
+            Relative bounds for the members of the sequence to follow, by default None
+        ask_count : int
+            Number of queries this agent has made
+        """
+
+        name = "sequential"
+
+        def __init__(
+            self,
+            *,
+            sequence: Sequence[Union[float, ArrayLike]],
+            relative_bounds: Tuple[Union[float, ArrayLike]] = None,
+            **kwargs,
+        ) -> None:
+            super().__init__(**kwargs)
+            self.independent_cache = []
+            self.observable_cache = []
+            self.sequence = sequence
+            self.relative_bounds = relative_bounds
+            self.ask_count = 0
+            self._position_generator = self._create_position_generator()
+
+        def _create_position_generator(self) -> Generator:
+            """Yield points from sequence if within bounds"""
+            for point in self.sequence:
+                if self.relative_bounds:
+                    arr = np.array(point)
+                    condition = arr <= self.relative_bounds[1] or arr >= self.relative_bounds[0]
+                    try:
+                        if condition:
+                            yield point
+                            continue
+                        else:
+                            logger.warning(
+                                f"Next point will be skipped.  {point} in sequence for {self.instance_name}, "
+                                f"is out of bounds {self.relative_bounds}"
+                            )
+                    except ValueError:  # Array not float
+                        if condition.all():
+                            yield arr
+                            continue
+                        else:
+                            logger.warning(
+                                f"Next point will be skipped.  {point} in sequence for {self.instance_name}, "
+                                f"is out of bounds {self.relative_bounds}"
+                            )
+                else:
+                    yield point
+
+        def tell(self, x, y) -> dict:
+            self.independent_cache.append(x)
+            self.observable_cache.append(y)
+            return dict(independent_variable=[x], observable=[y], cache_len=[len(self.independent_cache)])
+
+        def ask(self, batch_size: int = 1) -> Tuple[dict, Sequence]:
+            doc = defaultdict(list)
+            for _ in range(batch_size):
+                self.ask_count += 1
+                doc["proposal"].append(next(self._position_generator))
+            doc["ask_count"] = [self.ask_count]
+            return doc, doc["proposal"]
+
+        def report(self, **kwargs) -> dict:
+            return dict(percent_completion=[self.ask_count / len(self.sequence)])
+
+    class CMSBaseAgent:
+        measurement_plan_name = "simple_scan"
+
+        @staticmethod
+        def measurement_plan_args(point) -> list:
+            """
+            List of arguments to pass to plan from a point to measure.
+            This is a good place to transform relative into absolute motor coords.
+            """
+            return point
+
+        @staticmethod
+        def measurement_plan_kwargs(point) -> dict:
+            """
+            Construct dictionary of keyword arguments to pass the plan, from a point to measure.
+            This is a good place to transform relative into absolute motor coords.
+            """
+            return {}
+
+        def unpack_run(run: BlueskyRun) -> Tuple[Union[float, ArrayLike], Union[float, ArrayLike]]:
+            return run.start["experiment_state"], run.primary.data["detector"]
+
+        @staticmethod
+        def get_beamline_kwargs() -> dict:
+            beamline_tla = "cms"
+            kafka_config = nslsii.kafka_utils._read_bluesky_kafka_config_file(
+                config_file_path="/etc/bluesky/kafka.yml"
+            )
+            return dict(
+                kafka_group_id=f"echo-{beamline_tla}-{str(uuid.uuid4())[:8]}",
+                kafka_bootstrap_servers=kafka_config["bootstrap_servers"],
+                kafka_consumer_config=kafka_config["runengine_producer_config"],
+                kafka_producer_config=kafka_config["runengine_producer_config"],
+                publisher_topic=f"{beamline_tla}.bluesky.adjudicators",
+                subscripion_topics=[
+                    f"{beamline_tla}.bluesky.runengine.documents",
+                ],
+                data_profile_name=f"{beamline_tla}",
+                agent_profile_name=f"{beamline_tla}_bluesky_sandbox",
+                qserver_host=f"https://qserver.nsls2.bnl.gov/{beamline_tla}",
+                qserver_api_key=None,
+            )
+
+
+    class CMSSequentialAgent(SequentialAgentBase, CMSBaseAgent):
+        def __init__(
+            self,
+            *,
+            sequence: Sequence[Union[float, ArrayLike]],
+            relative_bounds: Tuple[Union[float, ArrayLike]] = None,
+            **kwargs,
+        ) -> None:
+            _default_kwargs = self.get_beamline_kwargs()
+            _default_kwargs.update(kwargs)
+            super().__init__(sequence=sequence, relative_bounds=relative_bounds, **_default_kwargs)

--- a/docs/source/distributed.rst
+++ b/docs/source/distributed.rst
@@ -170,6 +170,8 @@ as abstract in the base Agent.
             kafka_config = nslsii.kafka_utils._read_bluesky_kafka_config_file(
                 config_file_path="/etc/bluesky/kafka.yml"
             )
+            qs = REManagerAPI(http_server_uri=f"https://qserver.nsls2.bnl.gov/{beamline_tla}")
+            qs.set_authorization_key(api_key=None)
             return dict(
                 kafka_group_id=f"echo-{beamline_tla}-{str(uuid.uuid4())[:8]}",
                 kafka_bootstrap_servers=kafka_config["bootstrap_servers"],
@@ -181,8 +183,7 @@ as abstract in the base Agent.
                 ],
                 data_profile_name=f"{beamline_tla}",
                 agent_profile_name=f"{beamline_tla}_bluesky_sandbox",
-                qserver_host=f"https://qserver.nsls2.bnl.gov/{beamline_tla}",
-                qserver_api_key=None,
+                qserver=qs,
             )
 
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -15,6 +15,7 @@
    release-history
    min_versions
    examples
+   distributed
 
 .. warning::
 
@@ -252,5 +253,26 @@ science for a given amount of beamtime.
 
 In both of these cases the feedback is adding value without imposing a cost to
 the plans and the failure mode of the computation failing is the current status
-quo.  There are many ways that asynchronous feedback can be
-implemented and is out of scope for this package.
+quo.
+
+An increasingly desirable operating paradigm for autonomous experiments considers
+the directives of many agents, or even networks of agents,
+including multiple human agents. The previously described lock-step approaches to
+experiment and analysis, leave no room for human experts to engage in the loop,
+incorporation of information from complementary techniques, or the integration of
+multiple computational agents. In this more complex paradigm, various agents must be
+able to process the captured data stream, suggest plans to be executed,
+and create reports for human consumption. This is exemplified in the case where
+multiple passive agents are performing dataset factorization or AI-based compression
+algorithms that provide visualization tools for users,  multiple active learning
+agents are providing suggestions for next experiments as they complete their
+computation, and human agents are also guiding the experiment
+(see this `NeurIPS Workshop Paper <https://arxiv.org/abs/2301.09177>`_).
+
+Here, the same :code:`tell`, :code:`report`, :code:`ask` grammar can be used in conjunction with
+Kafka, Tiled, and the RunManager. This adds some additional dependencies including
+``bluesky-queueserver``, ``tiled``, and ``bluesky-kafka``.
+Examples of these agents are provided in :ref:`distributed`.
+Furthermore, using Kafka for distributed communication, one can construct meta-agents,
+or *adjudicators*, which coordinate between a collection of agents in more sophisticated ways
+than the RunManager priority queue and provide an additional avenue for human intervention.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,19 @@
+[tool.black]
+line-length = 115
+include = '\.pyi?$'
+exclude = '''
+/(
+    \.git
+  | \.hg
+  | \.mypy_cache
+  | \.tox
+  | \.venv
+  | _build
+  | buck-out
+  | build
+  | dist
+  # The following are specific to Black, you probably don't want those.
+  | blib2to3
+  | tests/data
+)/
+'''

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -17,3 +17,4 @@ databroker
 ophyd
 scipy
 pre-commit
+pytest-docker==1.0.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -18,3 +18,4 @@ ophyd
 scipy
 pre-commit
 pytest-docker==1.0.1
+git+https://github.com/bluesky/databroker.git@v2.0.0b13#egg=databroker

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -16,3 +16,4 @@ bluesky
 databroker
 ophyd
 scipy
+pre-commit

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,8 @@
 bluesky
 bluesky-live
 bluesky-widgets
+bluesky-kafka
+bluesky-queueserver-api
+xkcdpass
+tiled
 numpy


### PR DESCRIPTION
Moving the code from [MMM](https://github.com/NSLS-II-PDF/mmm-experiments) to Bluesky in a more robust manner. I've held off on complete adjudicator functionality for now, but will add in a future PR. 

@tacaswell Can you give this a once over to make sure it's on par with what you were expecting? Or would you prefer to hold off until some of the example docs and tests are done? 

- [x] Unit tests for kafka communications 
- [x] Address the concern of the Dispatcher not raising any errors with an open try statement.
- [x] Unit tests for race conditions and overflow of comms (moot with AgentManager plans)
- [x] Basic Mixins
  - [x] Unit test for simple mixins
  - [x] Unit tests for tiled coms
  - [x] Unit tests for plans on queue
- [x] Docs on Docs on Docs
  - [x] Extending this to NSLS-II specific example
