### PR TITLE
FIX: Document streaming model

### DIFF
--- a/bluesky_adaptive/agents/base.py
+++ b/bluesky_adaptive/agents/base.py
@@ -571,6 +571,14 @@ class Agent(ABC):
         return True
 
     def _tell(self, uid):
+        """Private tell to encapsulate the processing of a uid.
+        This allows the user tell to just consume an independent and dependent variable.
+
+        Parameters
+        ----------
+        uid : str
+            Unique key to grab from Tiled.
+        """
         run = self.exp_catalog[uid]
         try:
             independent_variable, dependent_variable = self.unpack_run(run)

--- a/bluesky_adaptive/agents/base.py
+++ b/bluesky_adaptive/agents/base.py
@@ -285,7 +285,10 @@ class Agent(ABC):
         self._direct_to_queue = direct_to_queue
         self.default_plan_md = dict(agent_name=self.instance_name, agent_class=str(type(self)))
         self.tell_cache = list()
-        self.server_registrations()
+        try:
+            self.server_registrations()
+        except RuntimeError as e:
+            logger.warning(f"Agent server unable to make registrations. Continuing regardless of\n {e}")
         self._kafka_thread = None
 
     @abstractmethod
@@ -633,7 +636,7 @@ class Agent(ABC):
             return
         logger.debug("Telling agent about some new data.")
         doc = self.tell(independent_variable, dependent_variable)
-        doc["exp_uid"] = [uid]
+        doc["exp_uid"] = uid
         self._write_event("tell", doc)
         self.tell_cache.append(uid)
 

--- a/bluesky_adaptive/agents/base.py
+++ b/bluesky_adaptive/agents/base.py
@@ -524,7 +524,7 @@ class Agent(ABC):
         uid : str
         re_manager : Optional[bluesky_queueserver_api.api_threads.API_Threads_Mixin]
             Defaults to self.re_manager
-        position : Optional[Union[int, Literal[&quot;front&quot;, &quot;back&quot;]]]
+        position : Optional[Union[int, Literal['front', 'back']]]
             Defaults to self.queue_add_position
 
         Returns

--- a/bluesky_adaptive/tests/conftest.py
+++ b/bluesky_adaptive/tests/conftest.py
@@ -8,6 +8,7 @@ from bluesky_kafka.tests.conftest import publisher_factory  # noqa
 from bluesky_kafka.tests.conftest import pytest_addoption  # noqa
 from bluesky_kafka.tests.conftest import temporary_topics  # noqa
 from bluesky_kafka.tests.conftest import consume_documents_from_kafka_until_first_stop_document  # noqa
+
 from ophyd.tests.conftest import hw  # noqa
 
 from tiled.client import from_profile

--- a/bluesky_adaptive/tests/test_sklearn_agents.py
+++ b/bluesky_adaptive/tests/test_sklearn_agents.py
@@ -1,9 +1,11 @@
+import time as ttime
 from typing import Tuple, Union
 
 import numpy as np
 import pytest
+from bluesky import RunEngine
+from bluesky.plans import count
 from bluesky_kafka import Publisher
-from bluesky_live.run_builder import RunBuilder
 from bluesky_queueserver_api.http import REManagerAPI
 from databroker.client import BlueskyRun
 from numpy.typing import ArrayLike
@@ -26,7 +28,7 @@ class DummyAgentMixin:
             topics=[sub_topic],
             bootstrap_servers=kafka_bootstrap_servers,
             group_id="test.communication.group",
-            consumer_config={"auto.offset.reset": "latest"},
+            consumer_config={"auto.offset.reset": "earliest"},
         )
 
         kafka_producer = Publisher(
@@ -47,20 +49,14 @@ class DummyAgentMixin:
             qserver=qs,
             **kwargs,
         )
+        self.counter = 0
 
     def measurement_plan(self, point: ArrayLike) -> Tuple[str, list, dict]:
         return self.measurement_plan_name, [1.5], dict()
 
     def unpack_run(self, run: BlueskyRun) -> Tuple[Union[float, ArrayLike], Union[float, ArrayLike]]:
-        return 0, 0
-
-    def start(self):
-        """Start without kafka consumer start"""
-        self.builder = RunBuilder(metadata=self.metadata)
-        self.agent_catalog.v1.insert("start", self.builder._cache.start_doc)
-
-    def server_registrations(self) -> None:
-        return None
+        self.counter += 1
+        return self.counter, np.random.rand(10)
 
 
 class TestDecompAgent(DummyAgentMixin, DecompositionAgentBase):
@@ -75,6 +71,7 @@ class TestClusterAgent(DummyAgentMixin, ClusterAgentBase):
 def test_decomp_agent(
     estimator, temporary_topics, kafka_bootstrap_servers, broker_authorization_config, tiled_profile, tiled_node
 ):
+    """Tests decomposition agents reporting and readback of reports."""
     with temporary_topics(topics=["test.publisher", "test.subscriber"]) as (pub_topic, sub_topic):
         agent = TestDecompAgent(
             pub_topic,
@@ -87,13 +84,89 @@ def test_decomp_agent(
         agent.start()
         for i in range(5):
             agent.tell(float(i), np.random.rand(10))
-            agent.tell_cache.append(i)  # dummy uid
+            agent.tell_cache.append(f"uid{i}")  # dummy uid
+        agent.generate_report()
+        xr = tiled_node[-1].report.read()
+        assert xr.components.shape == (1, 2, 10)  # shape after 1 report
+        assert xr.latest_data[-1].data == "uid4"  # most recent uid
 
+        for i in range(5, 10):
+            agent.tell(float(i), np.random.rand(10))
+            agent.tell_cache.append(f"uid{i}")  # dummy uid
         agent.generate_report()
         assert "report" in tiled_node[-1]
-        # TODO: Test shapes and reading of output
 
+        # Letting mongo catch up then checking for 2 reports
+        now = ttime.monotonic()
+        while len(tiled_node[-1].report.read().time) == 1:
+            ttime.sleep(0.5)
+            if ttime.monotonic() - now > 10:
+                break
+
+        xr = tiled_node[-1].report.read()
+        assert xr.components.shape == (2, 2, 10)
+        assert xr.latest_data[-1].data == "uid9"
         agent.stop()
+
+
+@pytest.mark.parametrize("estimator", [PCA(2), NMF(2)])
+def test_decomp_remodel_from_report(
+    estimator,
+    temporary_topics,
+    kafka_bootstrap_servers,
+    broker_authorization_config,
+    tiled_profile,
+    tiled_node,
+    hw,
+):
+    """Tests the rebuilding of the model from a given report, including the varaible shape pieces."""
+    with temporary_topics(topics=["test.publisher", "test.subscriber"]) as (pub_topic, sub_topic):
+        agent = TestDecompAgent(
+            pub_topic,
+            sub_topic,
+            kafka_bootstrap_servers,
+            broker_authorization_config,
+            tiled_profile,
+            estimator=estimator,
+        )
+        agent.start()
+        agent_uid = agent._compose_run_bundle.start_doc["uid"]
+        publisher = Publisher(
+            topic=sub_topic,
+            bootstrap_servers=kafka_bootstrap_servers,
+            producer_config=broker_authorization_config,
+            key=f"{sub_topic}.key",
+            flush_on_stop_doc=True,
+        )
+        RE = RunEngine()
+        RE.subscribe(publisher)
+        RE.subscribe(tiled_node.v1.insert)
+
+        for i in range(5):
+            RE(count([hw.det]))
+
+        # Letting mongo/kafka catch up to start/stop + 7 tells
+        now = ttime.monotonic()
+        while len(list(tiled_node[agent_uid].documents())) != 7:
+            ttime.sleep(0.5)
+            if ttime.monotonic() - now > 60:
+                break
+        assert "tell" in tiled_node[agent_uid]
+        agent.generate_report()
+        agent.stop()
+
+        # Letting mongo/kafka catch up to report
+        now = ttime.monotonic()
+        while not ("report" in tiled_node[agent_uid]):
+            ttime.sleep(0.5)
+            if ttime.monotonic() - now > 30:
+                break
+        model, data = agent.remodel_from_report(tiled_node[agent_uid])
+        assert isinstance(model, type(estimator))
+        assert data["components"].shape[0] == 2
+        assert data["weights"].shape == (5, 2)
+        assert len(data["observables"]) == 5
+        assert len(data["independent_vars"]) == 5
 
 
 @pytest.mark.parametrize("estimator", [KMeans(2)])


### PR DESCRIPTION
These changes fix two components of the document model: 
- Assuming the data keys and descriptors 
- Ensuring the example sklearn agents produce readable BlueskyRuns that can stack (fixed shape).

This changes from using `bluesky_live.RunBuilder` to using `event_model.compose_run` directly. This required several changes to the base class implementations of document streams.

The sklearn agents now have extensive testing that includes the assembly of agent BlueskyRuns, subscription to a run engine, and reconstructing all of the variable shape data from a recent `report`. These dimensionality reduction approaches now only write the fixed shape reduction, and now how the reduction relates to the entire dataset. E.g. NMF(k) produces a weights matrix (m, k) and components matrix (k, n), for data shaped (1, n) with m examples. All variability on m has been moved to a readback that uses a separate (or same) instance of the Agent subclass. 

Tagging @dmgav for visibility and optional review.  

