### PR TITLE
ENH: botorch example

### DIFF
--- a/bluesky_adaptive/agents/base.py
+++ b/bluesky_adaptive/agents/base.py
@@ -571,6 +571,14 @@ class Agent(ABC):
         return True
 
     def _tell(self, uid):
+        """Private tell to encapsulate the processing of a uid.
+        This allows the user tell to just consume an independent and dependent variable.
+
+        Parameters
+        ----------
+        uid : str
+            Unique key to grab from Tiled.
+        """
         run = self.exp_catalog[uid]
         try:
             independent_variable, dependent_variable = self.unpack_run(run)

--- a/bluesky_adaptive/agents/base.py
+++ b/bluesky_adaptive/agents/base.py
@@ -285,7 +285,10 @@ class Agent(ABC):
         self._direct_to_queue = direct_to_queue
         self.default_plan_md = dict(agent_name=self.instance_name, agent_class=str(type(self)))
         self.tell_cache = list()
-        self.server_registrations()
+        try:
+            self.server_registrations()
+        except RuntimeError as e:
+            logger.warning(f"Agent server unable to make registrations. Continuing regardless of\n {e}")
         self._kafka_thread = None
 
     @abstractmethod
@@ -633,7 +636,7 @@ class Agent(ABC):
             return
         logger.debug("Telling agent about some new data.")
         doc = self.tell(independent_variable, dependent_variable)
-        doc["exp_uid"] = [uid]
+        doc["exp_uid"] = uid
         self._write_event("tell", doc)
         self.tell_cache.append(uid)
 

--- a/bluesky_adaptive/agents/base.py
+++ b/bluesky_adaptive/agents/base.py
@@ -524,7 +524,7 @@ class Agent(ABC):
         uid : str
         re_manager : Optional[bluesky_queueserver_api.api_threads.API_Threads_Mixin]
             Defaults to self.re_manager
-        position : Optional[Union[int, Literal[&quot;front&quot;, &quot;back&quot;]]]
+        position : Optional[Union[int, Literal['front', 'back']]]
             Defaults to self.queue_add_position
 
         Returns

--- a/bluesky_adaptive/agents/botorch.py
+++ b/bluesky_adaptive/agents/botorch.py
@@ -68,7 +68,7 @@ class SingleTaskGPAgentBase(Agent, ABC):
         """
         super().__init__(**kwargs)
         self.inputs = None
-        self.observables = None
+        self.targets = None
 
         self.device = (
             torch.device("cuda" if torch.cuda.is_available() else "cpu")

--- a/bluesky_adaptive/agents/botorch.py
+++ b/bluesky_adaptive/agents/botorch.py
@@ -1,0 +1,134 @@
+"""
+Basic BoTorch functionality, primarily for examples.
+
+These mixins act to fufill the abstract methods of blusky_adaptive.agents.Agent that are relevant to
+the decision making, and not the experimental specifics.
+
+Children will need to implement the following:
+Experiment specific:
+    - measurement_plan_name
+    - measurement_plan_args
+    - measurement_plan_kwargs
+    - unpack_run
+"""
+
+import importlib
+from abc import ABC
+from logging import getLogger
+from typing import Callable, Optional
+
+import torch
+from botorch import fit_gpytorch_mll
+from botorch.acquisition import UpperConfidenceBound
+from botorch.models import SingleTaskGP
+from botorch.optim import optimize_acqf
+from gpytorch.mlls import ExactMarginalLogLikelihood
+
+from bluesky_adaptive.agents.base import Agent
+
+logger = getLogger("bluesky_adaptive.agents")
+
+
+class SingleTaskGPAgentBase(Agent, ABC):
+    def __init__(
+        self,
+        *,
+        bounds: torch.Tensor,
+        gp: SingleTaskGP = None,
+        device: torch.device = None,
+        out_dim=1,
+        partial_acq_function: Optional[Callable] = None,
+        num_restarts: int = 10,
+        **kwargs
+    ):
+        """Single Task GP based Bayesian Optimization
+
+        Parameters
+        ----------
+        bounds : torch.Tensor
+            A `2 x d` tensor of lower and upper bounds for each column of `X`
+        gp : SingleTaskGP, optional
+            GP surrogate model to use, by default uses BoTorch default
+        device : torch.device, optional
+            Device, by default cuda if avail
+        out_dim : int, optional
+            Dimension of output predictions by surrogate model, by default 1
+        partial_acq_function : Optional[Callable], optional
+            Partial acquisition function that will take a single argument of a conditioned surrogate model.
+            By default UCB with beta at 0.1
+        num_restarts : int, optional
+            Number of restarts for optimizing the acquisition function, by default 10
+        """
+        super().__init__(**kwargs)
+        self.inputs = None
+        self.observables = None
+
+        self.device = (
+            torch.device("cuda" if torch.cuda.is_available() else "cpu")
+            if device is None
+            else torch.device(device)
+        )
+        self.bounds = torch.tensor(bounds, device=self.device)
+        if gp is None:
+            dummy_x, dummy_y = torch.randn(2, self.bounds.shape[-1]), torch.randn(2, out_dim)
+            gp = SingleTaskGP(dummy_x, dummy_y)
+
+        self.surrogate_model = gp
+        self.mll = ExactMarginalLogLikelihood(self.surrogate_model.likelihood, self.surrogate_model)
+
+        self.surrogate_model.to(self.device)
+        self.mll.to(self.device)
+
+        if partial_acq_function is None:
+            self._partial_acqf = lambda gp: UpperConfidenceBound(gp, beta=0.1)
+            self.acqf_name = "UpperConfidenceBound"
+        self._partial_acqf = partial_acq_function
+        self.acqf_name = "custom"
+        self.num_restarts = num_restarts
+
+    def server_registrations(self) -> None:
+        super().server_registrations()
+        self._register_method("update_acquisition_function")
+
+    def update_acquisition_function(self, acqf_name, **kwargs):
+        module = importlib.import_module("botorch.acquisition")
+        self.acqf_name = acqf_name
+        self._partial_acqf = lambda gp: getattr(module, acqf_name)(gp, **kwargs)
+        self.close_and_restart()
+
+    def start(self, *args, **kwargs):
+        _md = dict(acqf_name=self.acqf_name)
+        self.metadata.update(_md)
+        super().start(*args, **kwargs)
+
+    def tell(self, x, y):
+        if self.inputs is None:
+            self.inputs = torch.atleast_2d(torch.tensor(x))
+            self.targets = torch.atleast_1d(torch.tensor(y))
+        else:
+            self.inputs = torch.cat([self.inputs, torch.atleast_2d(torch.tensor(x))], dim=0)
+            self.targets = torch.cat([self.targets, torch.atleast_1d(torch.tensor(y))], dim=0)
+        self.surrogate_model.set_train_data(self.inputs, self.targets, strict=False)
+        return dict(independent_variable=x, observable=y, cache_len=len(self.targets))
+
+    def report(self):
+        """Fit GP, and construct acquisition function.
+        Document retains state dictionary.
+        """
+        fit_gpytorch_mll(self.mll)
+        acqf = self._partial_acqf(self.surrogate_model)
+        return dict(state_dict=acqf.state_dict())
+
+    def ask(self, batch_size=1):
+        """Fit GP, optimize acquisition function, and return next points.
+        Document retains candidate, acquisition values, and state dictionary.
+        """
+        fit_gpytorch_mll(self.mll)
+        acqf = self._partial_acqf(self.surrogate_model)
+        candidate, acq_value = optimize_acqf(
+            acq_function=acqf, bounds=self.bounds, q=batch_size, num_restarts=self.num_restarts
+        )
+        return (
+            dict(candidate=candidate, acquisition_value=acq_value, state_dict=acqf.state_dict()),
+            torch.atleast_1d(candidate).detach().numpy(),
+        )

--- a/bluesky_adaptive/agents/sklearn.py
+++ b/bluesky_adaptive/agents/sklearn.py
@@ -200,17 +200,17 @@ class ClusterAgentBase(SklearnEstimatorAgentBase, ABC):
         independents, observables = zip(*sorted(zip(independents, observables)))
         arr = np.array(observables)
         try:
-            clusters = self.model.predict(arr)
-            distances = self.model.transform(arr)
+            clusters = model.predict(arr)
+            distances = model.transform(arr)
         except AttributeError:
             model.fit(arr)
             model.cluster_centers_ = run.report["data"]["cluster_centers"][idx]
-            clusters = self.model.predict(arr)
-            distances = self.model.transform(arr)
+            clusters = model.predict(arr)
+            distances = model.transform(arr)
         return model, dict(
             clusters=clusters,
             distances=distances,
-            cluster_centers=self.model.cluster_centers_,
+            cluster_centers=model.cluster_centers_,
             independent_vars=independents,
             observables=observables,
         )

--- a/bluesky_adaptive/agents/sklearn.py
+++ b/bluesky_adaptive/agents/sklearn.py
@@ -50,7 +50,7 @@ class SklearnEstimatorAgentBase(Agent, ABC):
     def tell(self, x, y):
         self.independent_cache.append(x)
         self.observable_cache.append(y)
-        return dict(independent_variable=[x], observable=[y], cache_len=[len(self.independent_cache)])
+        return dict(independent_variable=x, observable=y, cache_len=len(self.independent_cache))
 
     def ask(self, batch_size):
         raise NotImplementedError
@@ -94,7 +94,8 @@ class DecompositionAgentBase(SklearnEstimatorAgentBase, ABC):
             latest_data=self.tell_cache[-1],
         )
 
-    def remodel_from_report(self, run: BlueskyRun, idx: int = None) -> Tuple[sklearn.base.TransformerMixin, dict]:
+    @staticmethod
+    def remodel_from_report(run: BlueskyRun, idx: int = None) -> Tuple[sklearn.base.TransformerMixin, dict]:
         """Grabs specified (or most recent) report document and rebuilds modelling of dataset at that point.
 
         This enables fixed dimension reports that can be stacked and compared, while also allowing for
@@ -119,8 +120,9 @@ class DecompositionAgentBase(SklearnEstimatorAgentBase, ABC):
         model.components_ = run.report["data"]["components"][idx]
         latest_uid = run.report["data"]["latest_data"][idx]
         independents, observables = [], []
-        for uid in run.tell["data"]["exp_uid"]:
-            ind, obs = self.unpack_run(uid)
+        for ind, obs, uid in zip(
+            run.tell["data"]["independent_variable"], run.tell["data"]["observable"], run.tell["data"]["exp_uid"]
+        ):
             independents.append(ind)
             observables.append(obs)
             if uid == latest_uid:
@@ -166,7 +168,8 @@ class ClusterAgentBase(SklearnEstimatorAgentBase, ABC):
             latest_data=self.tell_cache[-1],
         )
 
-    def remodel_from_report(self, run: BlueskyRun, idx: int = None) -> Tuple[sklearn.base.TransformerMixin, dict]:
+    @staticmethod
+    def remodel_from_report(run: BlueskyRun, idx: int = None) -> Tuple[sklearn.base.TransformerMixin, dict]:
         """Grabs specified (or most recent) report document and rebuilds modelling of dataset at that point.
 
         This enables fixed dimension reports that can be stacked and compared, while also allowing for
@@ -191,8 +194,9 @@ class ClusterAgentBase(SklearnEstimatorAgentBase, ABC):
         model.cluster_centers_ = run.report["data"]["cluster_centers"][idx]
         latest_uid = run.report["data"]["latest_data"][idx]
         independents, observables = [], []
-        for uid in run.tell["data"]["exp_uid"]:
-            ind, obs = self.unpack_run(uid)
+        for ind, obs, uid in zip(
+            run.tell["data"]["independent_variable"], run.tell["data"]["observable"], run.tell["data"]["exp_uid"]
+        ):
             independents.append(ind)
             observables.append(obs)
             if uid == latest_uid:

--- a/bluesky_adaptive/tests/conftest.py
+++ b/bluesky_adaptive/tests/conftest.py
@@ -8,6 +8,7 @@ from bluesky_kafka.tests.conftest import publisher_factory  # noqa
 from bluesky_kafka.tests.conftest import pytest_addoption  # noqa
 from bluesky_kafka.tests.conftest import temporary_topics  # noqa
 from bluesky_kafka.tests.conftest import consume_documents_from_kafka_until_first_stop_document  # noqa
+
 from ophyd.tests.conftest import hw  # noqa
 
 from tiled.client import from_profile

--- a/bluesky_adaptive/tests/test_botorch_agents.py
+++ b/bluesky_adaptive/tests/test_botorch_agents.py
@@ -1,0 +1,88 @@
+from typing import Tuple, Union
+
+import numpy as np
+import torch
+from databroker.client import BlueskyRun
+from numpy.typing import ArrayLike
+from tiled.client import from_profile
+from xarray import Dataset
+
+from bluesky_adaptive.agents.botorch import SingleTaskGPAgentBase
+
+
+class OfflineKafka:
+    def set_agent(self, *args, **kwargs):
+        pass
+
+    def subscribe(self, *args, **kwargs):
+        pass
+
+    def start(self, *args, **kwargs):
+        pass
+
+    def flush(self, *args, **kwargs):
+        pass
+
+    def stop(self, *args, **kwargs):
+        pass
+
+
+class OfflineAgentMixin:
+    def __init__(self, tiled_profile, **kwargs):
+        qs = None
+        kafka_consumer = OfflineKafka()
+        kafka_producer = OfflineKafka()
+        tiled_data_node = from_profile(tiled_profile)
+        tiled_agent_node = from_profile(tiled_profile)
+        super().__init__(
+            kafka_consumer=kafka_consumer,
+            kafka_producer=kafka_producer,
+            tiled_agent_node=tiled_agent_node,
+            tiled_data_node=tiled_data_node,
+            qserver=qs,
+            ask_on_tell=False,
+            **kwargs,
+        )
+        self.counter = 0
+
+    def measurement_plan(self, point: ArrayLike) -> Tuple[str, list, dict]:
+        return self.measurement_plan_name, [1.5], dict()
+
+    def unpack_run(self, run: BlueskyRun) -> Tuple[Union[float, ArrayLike], Union[float, ArrayLike]]:
+        self.counter += 1
+        return self.counter, np.random.rand(10)
+
+
+class TestGPAgent(OfflineAgentMixin, SingleTaskGPAgentBase):
+    ...
+
+
+def test_gp_agent(tiled_profile, tiled_node):
+    # Test tell, ask, and report
+    bounds = torch.Tensor([(0, 1), (0, 1)])
+    agent = TestGPAgent(tiled_profile, bounds=bounds)
+    agent.start()
+    agent_uid = agent._compose_run_bundle.start_doc["uid"]
+    for i in range(5):
+        uid = f"uid{i}"
+        x = np.random.rand(2)
+        y = 1 - np.sum(np.sin(x)) + np.random.rand() * 0.01
+        doc = agent.tell(x, y)
+        doc["exp_uid"] = uid
+        agent._write_event("tell", doc)
+        agent.tell_cache.append(uid)
+    agent.generate_report()
+    doc, query = agent.ask()
+    agent._write_event("ask", doc)
+    doc, query = agent.ask()
+    agent._write_event("ask", doc)
+    agent.stop()
+    assert len(query) == 1
+    run = tiled_node[agent_uid]
+    xr = run.ask.read()
+    assert xr["candidate"].shape == (2, 1, 2)
+    assert xr["acquisition_value"].shape == (2,)
+    xr = run.report.read()
+    assert xr["STATEDICT-beta"].shape == (1,)
+    xr = run.tell.read()
+    assert isinstance(xr, Dataset)

--- a/bluesky_adaptive/tests/test_sklearn_agents.py
+++ b/bluesky_adaptive/tests/test_sklearn_agents.py
@@ -1,9 +1,11 @@
+import time as ttime
 from typing import Tuple, Union
 
 import numpy as np
 import pytest
+from bluesky import RunEngine
+from bluesky.plans import count
 from bluesky_kafka import Publisher
-from bluesky_live.run_builder import RunBuilder
 from bluesky_queueserver_api.http import REManagerAPI
 from databroker.client import BlueskyRun
 from numpy.typing import ArrayLike
@@ -26,7 +28,7 @@ class DummyAgentMixin:
             topics=[sub_topic],
             bootstrap_servers=kafka_bootstrap_servers,
             group_id="test.communication.group",
-            consumer_config={"auto.offset.reset": "latest"},
+            consumer_config={"auto.offset.reset": "earliest"},
         )
 
         kafka_producer = Publisher(
@@ -47,20 +49,14 @@ class DummyAgentMixin:
             qserver=qs,
             **kwargs,
         )
+        self.counter = 0
 
     def measurement_plan(self, point: ArrayLike) -> Tuple[str, list, dict]:
         return self.measurement_plan_name, [1.5], dict()
 
     def unpack_run(self, run: BlueskyRun) -> Tuple[Union[float, ArrayLike], Union[float, ArrayLike]]:
-        return 0, 0
-
-    def start(self):
-        """Start without kafka consumer start"""
-        self.builder = RunBuilder(metadata=self.metadata)
-        self.agent_catalog.v1.insert("start", self.builder._cache.start_doc)
-
-    def server_registrations(self) -> None:
-        return None
+        self.counter += 1
+        return self.counter, np.random.rand(10)
 
 
 class TestDecompAgent(DummyAgentMixin, DecompositionAgentBase):
@@ -75,6 +71,7 @@ class TestClusterAgent(DummyAgentMixin, ClusterAgentBase):
 def test_decomp_agent(
     estimator, temporary_topics, kafka_bootstrap_servers, broker_authorization_config, tiled_profile, tiled_node
 ):
+    """Tests decomposition agents reporting and readback of reports."""
     with temporary_topics(topics=["test.publisher", "test.subscriber"]) as (pub_topic, sub_topic):
         agent = TestDecompAgent(
             pub_topic,
@@ -87,13 +84,89 @@ def test_decomp_agent(
         agent.start()
         for i in range(5):
             agent.tell(float(i), np.random.rand(10))
-            agent.tell_cache.append(i)  # dummy uid
+            agent.tell_cache.append(f"uid{i}")  # dummy uid
+        agent.generate_report()
+        xr = tiled_node[-1].report.read()
+        assert xr.components.shape == (1, 2, 10)  # shape after 1 report
+        assert xr.latest_data[-1].data == "uid4"  # most recent uid
 
+        for i in range(5, 10):
+            agent.tell(float(i), np.random.rand(10))
+            agent.tell_cache.append(f"uid{i}")  # dummy uid
         agent.generate_report()
         assert "report" in tiled_node[-1]
-        # TODO: Test shapes and reading of output
 
+        # Letting mongo catch up then checking for 2 reports
+        now = ttime.monotonic()
+        while len(tiled_node[-1].report.read().time) == 1:
+            ttime.sleep(0.5)
+            if ttime.monotonic() - now > 10:
+                break
+
+        xr = tiled_node[-1].report.read()
+        assert xr.components.shape == (2, 2, 10)
+        assert xr.latest_data[-1].data == "uid9"
         agent.stop()
+
+
+@pytest.mark.parametrize("estimator", [PCA(2), NMF(2)])
+def test_decomp_remodel_from_report(
+    estimator,
+    temporary_topics,
+    kafka_bootstrap_servers,
+    broker_authorization_config,
+    tiled_profile,
+    tiled_node,
+    hw,
+):
+    """Tests the rebuilding of the model from a given report, including the varaible shape pieces."""
+    with temporary_topics(topics=["test.publisher", "test.subscriber"]) as (pub_topic, sub_topic):
+        agent = TestDecompAgent(
+            pub_topic,
+            sub_topic,
+            kafka_bootstrap_servers,
+            broker_authorization_config,
+            tiled_profile,
+            estimator=estimator,
+        )
+        agent.start()
+        agent_uid = agent._compose_run_bundle.start_doc["uid"]
+        publisher = Publisher(
+            topic=sub_topic,
+            bootstrap_servers=kafka_bootstrap_servers,
+            producer_config=broker_authorization_config,
+            key=f"{sub_topic}.key",
+            flush_on_stop_doc=True,
+        )
+        RE = RunEngine()
+        RE.subscribe(publisher)
+        RE.subscribe(tiled_node.v1.insert)
+
+        for i in range(5):
+            RE(count([hw.det]))
+
+        # Letting mongo/kafka catch up to start/stop + 7 tells
+        now = ttime.monotonic()
+        while len(list(tiled_node[agent_uid].documents())) != 7:
+            ttime.sleep(0.5)
+            if ttime.monotonic() - now > 60:
+                break
+        assert "tell" in tiled_node[agent_uid]
+        agent.generate_report()
+        agent.stop()
+
+        # Letting mongo/kafka catch up to report
+        now = ttime.monotonic()
+        while not ("report" in tiled_node[agent_uid]):
+            ttime.sleep(0.5)
+            if ttime.monotonic() - now > 30:
+                break
+        model, data = agent.remodel_from_report(tiled_node[agent_uid])
+        assert isinstance(model, type(estimator))
+        assert data["components"].shape[0] == 2
+        assert data["weights"].shape == (5, 2)
+        assert len(data["observables"]) == 5
+        assert len(data["independent_vars"]) == 5
 
 
 @pytest.mark.parametrize("estimator", [KMeans(2)])


### PR DESCRIPTION
Develops a relatively trivial Gaussian Process example in BoTorch. 
While this can be used out of the box, a generic agent GP is hardly experiment specific. This primarily demonstrates how to build and reuse such an agent, along with the appropriate document model for storing the `ask` and `reports`. 

I tried to balance utility and generalizability here. This uses basic optimizers from scipy, and default kernels for the GP. More advanced approaches for complex spaces would use torch implementations of the optimizers, monte carlo searches over acquisition functions, and custom kernels. All of this can be accomplished and is well documented by [BoTorch](https://github.com/pytorch/botorch); however, it should be left to the specific researcher for now.

This also adds the ability to rebuild passive sklearn models from an agent run and specific report, that is redundant with #13, but fixes a few minor things.  
