### PR TITLE
API: Fix ask many

### DIFF
--- a/bluesky_adaptive/agents/base.py
+++ b/bluesky_adaptive/agents/base.py
@@ -575,7 +575,7 @@ class Agent(ABC):
             doc["suggestion"] = next_point
             doc["batch_idx"] = batch_idx
             doc["batch_size"] = len(next_points)
-            self._write_event("ask", doc, uid=uid)
+            self._write_event("ask", doc, uid=f"{uid}/{batch_idx}")
         logger.info(f"Issued ask and adding to the queue. {uid}")
         self._add_to_queue(next_points, uid)
         self._check_queue_and_start()  # TODO: remove this and encourage updated qserver functionality

--- a/bluesky_adaptive/agents/base.py
+++ b/bluesky_adaptive/agents/base.py
@@ -334,7 +334,7 @@ class Agent(ABC):
         ...
 
     @abstractmethod
-    def tell(self, x, y) -> Dict[str, List]:
+    def tell(self, x, y) -> Dict[str, ArrayLike]:
         """
         Tell the agent about some new data
         Parameters
@@ -353,7 +353,7 @@ class Agent(ABC):
         ...
 
     @abstractmethod
-    def ask(self, batch_size: int) -> Tuple[Dict[str, List], Sequence]:
+    def ask(self, batch_size: int) -> Tuple[Sequence[Dict[str, ArrayLike]], Sequence[ArrayLike]]:
         """
         Ask the agent for a new batch of points to measure.
 
@@ -364,15 +364,15 @@ class Agent(ABC):
 
         Returns
         -------
-        doc : dict
-            key metadata from the ask approach
+        docs : Sequence[dict]
+            Documents of key metadata from the ask approach for each point in next_points.
+            Must be length of batch size.
         next_points : Sequence
             Sequence of independent variables of length batch size
-
         """
         ...
 
-    def report(self, **kwargs) -> Dict[str, List]:
+    def report(self, **kwargs) -> Dict[str, ArrayLike]:
         """
         Create a report given the data observed by the agent.
         This could be potentially implemented in the base class to write document stream.
@@ -569,9 +569,9 @@ class Agent(ABC):
         """Calls ask, adds suggestions to queue, and writes out events.
         This will create one event for each suggestion.
         """
-        doc, next_points = self.ask(batch_size)
+        docs, next_points = self.ask(batch_size)
         uid = str(uuid.uuid4())
-        for batch_idx, next_point in enumerate(next_points):
+        for batch_idx, (doc, next_point) in enumerate(zip(docs, next_points)):
             doc["suggestion"] = next_point
             doc["batch_idx"] = batch_idx
             doc["batch_size"] = len(next_points)

--- a/bluesky_adaptive/agents/base.py
+++ b/bluesky_adaptive/agents/base.py
@@ -574,6 +574,7 @@ class Agent(ABC):
         for batch_idx, next_point in enumerate(next_points):
             doc["suggestion"] = next_point
             doc["batch_idx"] = batch_idx
+            doc["batch_size"] = len(next_points)
             self._write_event("ask", doc, uid=uid)
         logger.info(f"Issued ask and adding to the queue. {uid}")
         self._add_to_queue(next_points, uid)

--- a/bluesky_adaptive/agents/simple.py
+++ b/bluesky_adaptive/agents/simple.py
@@ -15,7 +15,6 @@ Experiment specific:
     - unpack_run
 """
 from abc import ABC
-from collections import defaultdict
 from logging import getLogger
 from typing import Generator, Sequence, Tuple, Union
 
@@ -98,15 +97,16 @@ class SequentialAgentBase(Agent, ABC):
     def tell(self, x, y) -> dict:
         self.independent_cache.append(x)
         self.observable_cache.append(y)
-        return dict(independent_variable=[x], observable=[y], cache_len=[len(self.independent_cache)])
+        return dict(independent_variable=x, observable=y, cache_len=len(self.independent_cache))
 
-    def ask(self, batch_size: int = 1) -> Tuple[dict, Sequence]:
-        doc = defaultdict(list)
+    def ask(self, batch_size: int = 1) -> Tuple[Sequence[dict[str, ArrayLike]], Sequence[ArrayLike]]:
+        docs = []
+        proposals = []
         for _ in range(batch_size):
             self.ask_count += 1
-            doc["proposal"].append(next(self._position_generator))
-        doc["ask_count"] = [self.ask_count]
-        return [doc], [doc["proposal"]]
+            proposals.append(next(self._position_generator))
+            docs.append(dict(proposal=proposals[-1], ask_count=self.ask_count))
+        return docs, proposals
 
     def report(self, **kwargs) -> dict:
-        return dict(percent_completion=[self.ask_count / len(self.sequence)])
+        return dict(percent_completion=self.ask_count / len(self.sequence))

--- a/bluesky_adaptive/agents/simple.py
+++ b/bluesky_adaptive/agents/simple.py
@@ -106,7 +106,7 @@ class SequentialAgentBase(Agent, ABC):
             self.ask_count += 1
             doc["proposal"].append(next(self._position_generator))
         doc["ask_count"] = [self.ask_count]
-        return doc, doc["proposal"]
+        return [doc], [doc["proposal"]]
 
     def report(self, **kwargs) -> dict:
         return dict(percent_completion=[self.ask_count / len(self.sequence)])

--- a/bluesky_adaptive/tests/test_botorch_agents.py
+++ b/bluesky_adaptive/tests/test_botorch_agents.py
@@ -74,9 +74,9 @@ def test_gp_agent(tiled_profile, tiled_node):
         agent.tell_cache.append(uid)
     agent.generate_report()
     doc, query = agent.ask()
-    agent._write_event("ask", doc)
+    agent._write_event("ask", doc[0])
     doc, query = agent.ask()
-    agent._write_event("ask", doc)
+    agent._write_event("ask", doc[0])
     agent.stop()
     assert len(query) == 1
     run = tiled_node[agent_uid]

--- a/docs/source/distributed.rst
+++ b/docs/source/distributed.rst
@@ -139,18 +139,19 @@ as well as the qserver API using some common configuration keys. Both are demons
         def tell(self, x, y) -> dict:
             self.independent_cache.append(x)
             self.observable_cache.append(y)
-            return dict(independent_variable=[x], observable=[y], cache_len=[len(self.independent_cache)])
+            return dict(independent_variable=x, observable=y, cache_len=len(self.independent_cache))
 
-        def ask(self, batch_size: int = 1) -> Tuple[dict, Sequence]:
-            doc = defaultdict(list)
+        def ask(self, batch_size: int = 1) -> Tuple[Sequence[dict[str, ArrayLike]], Sequence[ArrayLike]]:
+            docs = []
+            proposals = []
             for _ in range(batch_size):
                 self.ask_count += 1
-                doc["proposal"].append(next(self._position_generator))
-            doc["ask_count"] = [self.ask_count]
-            return doc, doc["proposal"]
+                proposals.append(next(self._position_generator))
+                docs.append(dict(proposal=proposals[-1], ask_count=self.ask_count))
+            return docs, proposals
 
         def report(self, **kwargs) -> dict:
-            return dict(percent_completion=[self.ask_count / len(self.sequence)])
+            return dict(percent_completion=self.ask_count / len(self.sequence))
 
     class CMSBaseAgent:
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Change the behavior of `ask` to return a sequence of documents and sequence suggestions/queries instead of a single document. 
## Description
<!--- Describe your changes in detail -->
This assigns many ask documents a common uid associated with a given ask call, and logs the batch index and the suggestion by default. Changes were propagated to the `MonarchSubject` agent base, and Botorch and simple agents. The Sklearn agents are passive (no ask) and remain unaffected. 
This creates an  API burden to the user to enforce single docs be encapsulated in a list (as single points already were).

Core internal change with default keys is here, with other changes made to docs and for agent consistency. 
```python
docs, next_points = self.ask(batch_size)
uid = str(uuid.uuid4())
for batch_idx, (doc, next_point) in enumerate(zip(docs, next_points)):
    doc["suggestion"] = next_point
    doc["batch_idx"] = batch_idx
    doc["batch_size"] = len(next_points)
    self._write_event("ask", doc, uid=uid)
``` 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This ensures that variable batch sizes can be stacked in a common data array. Initially it was though sufficient to just update a single `ask` doc as many docs with common metadata and different `suggestion` fields. However, there is often metadata associated with each individual suggestion that should be propagated through (e.g. in BoTorch we want to carry the suggestions and their associated acquisition value). 

## Summary of Changes for Release Notes
<!--- Brief summary of changes that could be copied to the Release Notes. -->
<!--- Skip this section if this is a maintenace PR (CI, unit tests, typo fix etc.) -->
<!--- PRs with feature changes will not be merged without this section filled. -->

<!--- Group the changes in the following sections: -->

### Fixed

### Added

### Changed
API change for `ask -> Tuple[Sequence[Dict[str, ArrayLike]], Sequence[ArrayLike]]`
### Removed

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Running all unit tests sequentially using docker container for qserver, httpserver, mongo, and kafka. 
<!--
## Screenshots (if appropriate):
-->
