### PR TITLE
ENH: Adjudicators

### DIFF
--- a/bluesky_adaptive/adjudicators/README-ADJUDICATORS.md
+++ b/bluesky_adaptive/adjudicators/README-ADJUDICATORS.md
@@ -1,6 +1,6 @@
 # Adjudicators
 
-The purpose of an adjudicator is to provide another layer of misdirection between the agents and the RunEngine Manager.
+The purpose of an adjudicator is to provide another layer of indirection between the agents and the RunEngine Manager.
 This is not required, as agents can send plans directly to the queue.
 Alternatively, many agents can send plans to an adjudicator that acts as a meta-agent, filtering and deciding which plans from many agents make it to the queue.
 In this way, the adjudicator acts as an extra experiment manager.

--- a/bluesky_adaptive/adjudicators/README-ADJUDICATORS.md
+++ b/bluesky_adaptive/adjudicators/README-ADJUDICATORS.md
@@ -1,0 +1,42 @@
+# Adjudicators
+
+The purpose of an adjudicator is to provide another layer of misdirection between the agents and the RunEngine Manager.
+This is not required, as agents can send plans directly to the queue.
+Alternatively, many agents can send plans to an adjudicator that acts as a meta-agent, filtering and deciding which plans from many agents make it to the queue.
+In this way, the adjudicator acts as an extra experiment manager.
+Feedback is not provided directly to the agents (i.e. no two way communication), so this is in effect, much like how high level human management communicates with low level employees.
+
+Each adjudicator is required to implement `make_judgments`, which accepts no args or kwargs, and should return a list of tuples that contain the RE manager API, the agent name, and the Suggestion.
+These tuples will by validated by Pydantic models, or can be `Judgment` objects.
+This enables an agent to suggest many plans at once, to multiple beamlines!
+Adjustable properties can be incorperated by the server, allowing for web and caproto control.
+
+`make_judgments` can be called promptly after every new document, or only on user command.
+
+
+## Use Case: Avoiding redundancy
+One challenge of having many agents who can write to the queue is they don't know what other agents are suggesting. This can cause multiple agents to have the same idea about the next experiment, and lead an autonomous experiment to run the same plans redundantly. For example, if I had two Bayesian optimization agents that were minimizing their surrogate model uncertainty, they may have a similar idea for the next best area to measure.
+An adjudicator can ensure that only one measurement gets scheduled, but both agents will still recive the data.
+
+## Use Case: Meta-analysis of many similar agents
+You may want to filter down the number of plans comming from multiple agents that are using the same underlying technique.
+This mechanism for increasing diversity could be applied to a suite of exploitative optimizers, or maybe complementary decomposition approaches (NMF/PCA/Kmeans) that are suggesting regions near their primary components.
+An adjudicator that is conducting analysis of many agents will take careful thought and should be tuned to the set of agents it is attending to.
+
+## Pydantic Message API Enables multi-experiment, multi-beamline suggestions
+```python
+suggestion = Suggestion(ask_uid="123", plan_name="test_plan", plan_args=[1, 3], plan_kwargs={"md": {}})
+msg = AdjudicatorMsg(
+    agent_name="aardvark",
+    suggestions_uid="456",
+    suggestions={
+        "pdf": [
+            suggestion,
+            suggestion,
+        ],
+        "bmm": [
+            suggestion,
+        ],
+    },
+)
+```

--- a/bluesky_adaptive/adjudicators/base.py
+++ b/bluesky_adaptive/adjudicators/base.py
@@ -64,7 +64,13 @@ class AdjudicatorBase(BlueskyConsumer, ABC):
         self._prompt = True
 
     def start(self, *args, **kwargs):
-        self._thread = Thread(target=self.start, name="adjudicator-loop", daemon=True, args=args, kwargs=kwargs)
+        self._thread = Thread(
+            target=BlueskyConsumer.start,
+            name="adjudicator-loop",
+            daemon=True,
+            args=[self] + list(args),
+            kwargs=kwargs,
+        )
         self._thread.start()
 
     def process_document(self, topic, name, doc):
@@ -128,7 +134,7 @@ class AdjudicatorBase(BlueskyConsumer, ABC):
                 judgment = Judgment(*judgment)  # Validate
             self._add_suggestion_to_queue(**judgment.dict())
 
-    @abstractmethod()
+    @abstractmethod
     def make_judgments(self) -> Sequence[Tuple[API_Threads_Mixin, str, Suggestion]]:
         """Instance method to make judgements based on current suggestions.
         The returned tuples will be deconstructed to add suggestions to the queue.
@@ -156,7 +162,7 @@ class AgentByNameAdjudicator(AdjudicatorBase):
 
     @primary_agent.setter
     def primary_agent(self, name: str):
-        self._primary_agent = "str"
+        self._primary_agent = name
 
     def server_registrations(self) -> None:
         self._register_property("priamry_agent")

--- a/bluesky_adaptive/adjudicators/base.py
+++ b/bluesky_adaptive/adjudicators/base.py
@@ -218,7 +218,6 @@ class NonredundantAdjudicator(AdjudicatorBase):
         hash_suggestion: Callable,
         **kwargs,
     ):
-
         super().__init__(topics, bootstrap_servers, group_id, *args, **kwargs)
         self.hash_suggestion = hash_suggestion
         self.suggestion_set = set()

--- a/bluesky_adaptive/adjudicators/base.py
+++ b/bluesky_adaptive/adjudicators/base.py
@@ -195,10 +195,10 @@ class NonredundantAdjudicator(AdjudicatorBase):
         expected in AdjudicatorMsg.suggestions dictionary.
     hash_suggestion : Callable
         Function that takes the tla and Suggestion object, and returns a hashable object as ::
-           
+
             def hash_suggestion(tla: str, suggestion: Suggestion) -> Hashable: ...
-            
-        
+
+
         This hashable object will be used to check redundancy in a set.
 
     Examples

--- a/bluesky_adaptive/adjudicators/base.py
+++ b/bluesky_adaptive/adjudicators/base.py
@@ -132,7 +132,7 @@ class AdjudicatorBase(BlueskyConsumer, ABC):
         for judgment in judgments:
             if not isinstance(judgment, Judgment):
                 judgment = Judgment(*judgment)  # Validate
-            self._add_suggestion_to_queue(**judgment.dict())
+            self._add_suggestion_to_queue(judgment.re_manager, judgment.agent_name, judgment.suggestion)
 
     @abstractmethod
     def make_judgments(self) -> Sequence[Tuple[API_Threads_Mixin, str, Suggestion]]:

--- a/bluesky_adaptive/adjudicators/base.py
+++ b/bluesky_adaptive/adjudicators/base.py
@@ -63,6 +63,11 @@ class AdjudicatorBase(BlueskyConsumer, ABC):
         self._ask_uids = DequeSet()
         self._prompt = True
 
+        try:
+            self.server_registrations()
+        except RuntimeError as e:
+            logger.warning(f"Agent server unable to make registrations. Continuing regardless of\n {e}")
+
     def start(self, *args, **kwargs):
         self._thread = Thread(
             target=BlueskyConsumer.start,
@@ -124,7 +129,8 @@ class AdjudicatorBase(BlueskyConsumer, ABC):
         This method can be used in subclasses, to override or extend the default registrations.
         """
         self._register_method("make_judgements", "_make_judgments_and_add_to_queue")
-        self._register_property("prompt_judgement")
+        self._register_property("prompt_judgment")
+        self._register_property("current_suggestions")
 
     def _make_judgments_and_add_to_queue(self):
         """Internal wrapper for making judgements, validating, and adding to queue."""

--- a/bluesky_adaptive/adjudicators/base.py
+++ b/bluesky_adaptive/adjudicators/base.py
@@ -194,7 +194,11 @@ class NonredundantAdjudicator(AdjudicatorBase):
         Dictionary of objects to manage communication with Queue Server. These should be keyed by the beamline TLA
         expected in AdjudicatorMsg.suggestions dictionary.
     hash_suggestion : Callable
-        Function that takes the tla and Suggestion object, and returns a hashable object.
+        Function that takes the tla and Suggestion object, and returns a hashable object as ::
+           
+            def hash_suggestion(tla: str, suggestion: Suggestion) -> Hashable: ...
+            
+        
         This hashable object will be used to check redundancy in a set.
 
     Examples

--- a/bluesky_adaptive/adjudicators/base.py
+++ b/bluesky_adaptive/adjudicators/base.py
@@ -1,0 +1,137 @@
+import logging
+from abc import ABC, abstractmethod
+from collections import deque
+from copy import deepcopy
+from threading import Lock, Thread
+from typing import Sequence, Tuple
+
+from bluesky_kafka import BlueskyConsumer
+from bluesky_queueserver_api import BPlan
+from bluesky_queueserver_api.api_threads import API_Threads_Mixin
+
+from bluesky_adaptive.adjudicators.msg import DEFAULT_NAME, AdjudicatorMsg, Judgment, Suggestion
+from bluesky_adaptive.agents.base import Agent as BaseAgent
+from bluesky_adaptive.server.demo.agent_sandbox import add_suggestions_to_queue
+
+logger = logging.getLogger(__name__)
+
+
+class DequeSet:
+    def __init__(self, maxlen=100):
+        self._set = set()
+        self._dequeue = deque()
+        self._maxlen = maxlen
+
+    def __contains__(self, d):
+        return d in self._set
+
+    def append(self, d):
+        if d in self:
+            logger.debug(f"Attempt to add redunt point to DequeSet ignored: {d}")
+            return
+        self._set.add(d)
+        self._dequeue.append(d)
+        while len(self._dequeue) >= self._maxlen:
+            discarded = self._dequeue.popleft()
+            self._set.remove(discarded)
+
+
+class AdjudicatorBase(BlueskyConsumer, ABC):
+    """
+    An agent adjudicator that listens to published suggestions by agents.
+    This Base approach (as per `process_document`) only retains the most recent suggestions by any named agents.
+    Other mechanisms for tracking can be provided
+
+    Parameters
+    ----------
+    topics : list of str
+        List of existing_topics as strings such as ["topic-1", "topic-2"]
+    bootstrap_servers : str
+        Comma-delimited list of Kafka server addresses as a string
+        such as ``'broker1:9092,broker2:9092,127.0.0.1:9092'``
+    group_id : str
+        Required string identifier for the consumer's Kafka Consumer group.
+    """
+
+    _register_method = BaseAgent._register_method
+    _register_property = BaseAgent._register_property
+
+    def __init__(self, topics: list[str], bootstrap_servers: str, group_id: str, *args, **kwargs):
+        super().__init__(topics, bootstrap_servers, group_id, *args, **kwargs)
+        self._lock = Lock()
+        self._thread = None
+        self._current_suggestions = {}  # agent_name: AdjudicatorMsg
+        self._ask_uids = DequeSet()
+        self._prompt = True
+
+    def start(self, *args, **kwargs):
+        self._thread = Thread(target=self.start, name="adjudicator-loop", daemon=True, args=args, kwargs=kwargs)
+        self._thread.start()
+
+    def process_document(self, topic, name, doc):
+        if name != DEFAULT_NAME:
+            return True
+        with self._lock:
+            logger.info(f"{doc['agent_name']=}, {doc['suggestions_uid']=}")
+            self._current_suggestions[doc["agent_name"]] = AdjudicatorMsg(**doc)
+
+        if self.prompt_judgment:
+            self._make_judgments_and_add_to_queue()
+
+    @property
+    def current_suggestions(self):
+        """Dictionary of {agent_name:AdjudicatorMsg}, deep copied at each grasp."""
+        with self._lock:
+            ret = deepcopy(self._current_suggestions)
+        return ret
+
+    @property
+    def agent_names(self):
+        with self._lock:
+            ret = list(self._current_suggestions.keys())
+        return ret
+
+    @property
+    def prompt_judgment(self) -> bool:
+        return self._prompt
+
+    @prompt_judgment.setter
+    def prompt_judgment(self, flag: bool):
+        self._prompt = flag
+
+    def add_suggestion_to_queue(self, re_manager: API_Threads_Mixin, agent_name: str, suggestion: Suggestion):
+        if suggestion.ask_uid in self._ask_uids:
+            logger.debug(f"Ask uid {suggestion.ask_uid} has already been seen. Not adding anything to the queue.")
+            return
+        else:
+            self._ask_uids.append(suggestion.ask_uid)
+        kwargs = suggestion.plan_kwargs
+        kwargs.setdefault("md", {})
+        kwargs["md"]["agent_ask_uid"] = suggestion.ask_uid
+        kwargs["md"]["agent_name"] = agent_name
+        plan = BPlan(suggestion.plan_name, *suggestion.plan_args, **kwargs)
+        r = re_manager.item_add(plan, pos="back")
+        logger.debug(f"Sent http-server request by adjudicator\n." f"Received reponse: {r}")
+
+    def server_registrations(self) -> None:
+        """
+        Method to generate all server registrations during agent initialization.
+        This method can be used in subclasses, to override or extend the default registrations.
+        """
+        self._register_method("make_judgements", "_make_judgements")
+        self._register_property("prompt_judgement")
+
+    def _make_judgments_and_add_to_queue(self):
+        """Internal wrapper for making judgements, validating, and adding to queue."""
+        judgments = self.make_judgments()
+        for judgment in judgments:
+            if not isinstance(judgment, Judgment):
+                judgment = Judgment(*judgment)  # Validate
+            add_suggestions_to_queue(**judgment.dict())
+
+    @abstractmethod()
+    def make_judgments(self) -> Sequence[Tuple[API_Threads_Mixin, str, Suggestion]]:
+        """Instance method to make judgements based on current suggestions.
+        The returned tuples will be deconstructed to add suggestions to the queue.
+        """
+        ...

--- a/bluesky_adaptive/adjudicators/msg.py
+++ b/bluesky_adaptive/adjudicators/msg.py
@@ -24,6 +24,9 @@ class Judgment(BaseModel):
     agent_name: str
     suggestion: Suggestion
 
+    class Config:
+        arbitrary_types_allowed = True
+
     def __init__(self, re_manager: API_Threads_Mixin, agent_name: str, suggestion: Suggestion, **kwargs) -> None:
         super().__init__(re_manager=re_manager, agent_name=agent_name, suggestion=suggestion, **kwargs)
 

--- a/bluesky_adaptive/adjudicators/msg.py
+++ b/bluesky_adaptive/adjudicators/msg.py
@@ -1,3 +1,5 @@
+from typing import AnyStr, Dict, List
+
 from bluesky_queueserver_api.api_threads import API_Threads_Mixin
 from pydantic import BaseModel
 
@@ -14,7 +16,7 @@ class Suggestion(BaseModel):
 class AdjudicatorMsg(BaseModel):
     agent_name: str
     suggestions_uid: str
-    suggestions: dict[str, list[Suggestion]]  # TLA: list
+    suggestions: Dict[AnyStr, List[Suggestion]]  # TLA: list
 
 
 class Judgment(BaseModel):

--- a/bluesky_adaptive/adjudicators/msg.py
+++ b/bluesky_adaptive/adjudicators/msg.py
@@ -1,0 +1,52 @@
+from bluesky_queueserver_api.api_threads import API_Threads_Mixin
+from pydantic import BaseModel
+
+DEFAULT_NAME = "agent_suggestions"
+
+
+class Suggestion(BaseModel):
+    ask_uid: str  # UID from the agent ask message
+    plan_name: str
+    plan_args: list = []
+    plan_kwargs: dict = {}
+
+
+class AdjudicatorMsg(BaseModel):
+    agent_name: str
+    suggestions_uid: str
+    suggestions: dict[str, list[Suggestion]]  # TLA: list
+
+
+class Judgment(BaseModel):
+    """Allow for positional arguments from user derived make judgements"""
+
+    re_manager: API_Threads_Mixin
+    agent_name: str
+    suggestion: Suggestion
+
+    def __init__(self, re_manager: API_Threads_Mixin, agent_name: str, suggestion: Suggestion, **kwargs) -> None:
+        super().__init__(re_manager=re_manager, agent_name=agent_name, suggestion=suggestion, **kwargs)
+
+
+if __name__ == "__main__":
+    """Example main to show serializing capabilities"""
+    import msgpack
+
+    suggestion = Suggestion(ask_uid="123", plan_name="test_plan", plan_args=[1, 3], plan_kwargs={"md": {}})
+    msg = AdjudicatorMsg(
+        agent_name="aardvark",
+        suggestions_uid="456",
+        suggestions={
+            "pdf": [
+                suggestion,
+                suggestion,
+            ],
+            "bmm": [
+                suggestion,
+            ],
+        },
+    )
+    print(msg)
+    s = msgpack.dumps(msg.dict())
+    new_msg = AdjudicatorMsg(**msgpack.loads(s))
+    print(new_msg)

--- a/bluesky_adaptive/agents/base.py
+++ b/bluesky_adaptive/agents/base.py
@@ -20,9 +20,9 @@ from event_model import compose_run
 from numpy.typing import ArrayLike
 from xkcdpass import xkcd_password as xp
 
-from bluesky_adaptive.adjudicators.msg import DEFAULT_NAME as ADJUDICATOR_STREAM_NAME
-from bluesky_adaptive.adjudicators.msg import AdjudicatorMsg, Suggestion
-from bluesky_adaptive.server import register_variable, start_task
+from ..adjudicators.msg import DEFAULT_NAME as ADJUDICATOR_STREAM_NAME
+from ..adjudicators.msg import AdjudicatorMsg, Suggestion
+from ..server import register_variable, start_task
 
 logger = getLogger("bluesky_adaptive.agents")
 PASSWORD_LIST = xp.generate_wordlist(wordfile=xp.locate_wordfile(), min_length=3, max_length=6)

--- a/bluesky_adaptive/agents/base.py
+++ b/bluesky_adaptive/agents/base.py
@@ -204,8 +204,8 @@ class Agent(ABC):
         Bluesky stop documents that will trigger ``tell``.
         AgentConsumer is a child class of bluesky_kafka.RemoteDispatcher that enables
         kafka messages to trigger agent directives.
-    kafka_producer : Publisher
-        Bluesky Kafka publisher to produce document stream of agent actions.
+    kafka_producer : Optional[Publisher]
+        Bluesky Kafka publisher to produce document stream of agent actions for optional Adjudicator.
     tiled_data_node : tiled.client.node.Node
         Tiled node to serve as source of data (BlueskyRuns) for the agent.
     tiled_agent_node : tiled.client.node.Node
@@ -246,10 +246,10 @@ class Agent(ABC):
         self,
         *,
         kafka_consumer: AgentConsumer,
-        kafka_producer: Publisher,
         tiled_data_node: tiled.client.node.Node,
         tiled_agent_node: tiled.client.node.Node,
         qserver: API_Threads_Mixin,
+        kafka_producer: Optional[Publisher],
         agent_run_suffix: Optional[str] = None,
         metadata: Optional[dict] = None,
         ask_on_tell: Optional[bool] = True,
@@ -946,8 +946,8 @@ class MonarchSubjectAgent(Agent, ABC):
         self,
         *args,
         subject_qserver: API_Threads_Mixin,
-        subject_kafka_producer: Publisher,
-        subject_endstation_key: Optional[str] = "",  # TODO: Make producer optional since Adjudicator is
+        subject_kafka_producer: Optional[Publisher] = None,
+        subject_endstation_key: Optional[str] = "",
         **kwargs,
     ):
         """Abstract base class for a MonarchSubject agent. These agents only consume documents from one
@@ -978,7 +978,7 @@ class MonarchSubjectAgent(Agent, ABC):
         ----------
         subject_qserver : API_Threads_Mixin
             Object to manage communication with the Subject Queue Server
-        subject_kafka_producer : Publisher
+        subject_kafka_producer : Optional[Publisher]
             Bluesky Kafka publisher to produce document stream of agent actions to Adjudicators
         subject_endstation_key : Optional[str]
             Optional string that is needed for Adjudicator functionality. This keys the qserver API instance to

--- a/bluesky_adaptive/server/demo/adjudicator_sandbox.py
+++ b/bluesky_adaptive/server/demo/adjudicator_sandbox.py
@@ -1,0 +1,72 @@
+# BS_AGENT_STARTUP_SCRIPT_PATH=./bluesky_adaptive/server/demo/adjudicator_sandbox.py \
+# uvicorn bluesky_adaptive.server:app
+from bluesky_kafka.utils import create_topics, delete_topics
+from bluesky_queueserver_api.http import REManagerAPI
+
+from bluesky_adaptive.adjudicators.base import NonredundantAdjudicator
+from bluesky_adaptive.adjudicators.msg import Suggestion
+from bluesky_adaptive.server import shutdown_decorator, startup_decorator
+
+broker_authorization_config = {
+    "acks": 1,
+    "enable.idempotence": False,
+    "request.timeout.ms": 1000,
+    "bootstrap.servers": "127.0.0.1:9092",
+}
+tiled_profile = "testing_sandbox"
+kafka_bootstrap_servers = "127.0.0.1:9092"
+bootstrap_servers = kafka_bootstrap_servers
+admin_client_config = broker_authorization_config
+topics = ["test.publisher", "test.subscriber"]
+adj_topic, sub_topic = topics
+
+
+re_manager = REManagerAPI(http_server_uri=None)
+re_manager.set_authorization_key(api_key="SECRET")
+
+
+def _hash_suggestion(tla, suggestion: Suggestion):
+    return f"{tla} {suggestion.plan_name} {str(suggestion.plan_args)}"
+
+
+adjudicator = NonredundantAdjudicator(
+    topics=[adj_topic],
+    bootstrap_servers=kafka_bootstrap_servers,
+    group_id="test.communication.group",
+    qservers={"tst": re_manager},
+    consumer_config={"auto.offset.reset": "earliest"},
+    hash_suggestion=_hash_suggestion,
+)
+
+
+@startup_decorator
+def startup_topics():
+    delete_topics(
+        bootstrap_servers=bootstrap_servers,
+        topics_to_delete=topics,
+        admin_client_config=admin_client_config,
+    )
+    create_topics(
+        bootstrap_servers=bootstrap_servers,
+        topics_to_create=topics,
+        admin_client_config=admin_client_config,
+    )
+
+
+@startup_decorator
+def startup_adjudicator():
+    adjudicator.start()
+
+
+@shutdown_decorator
+def shutdown_agent():
+    return adjudicator.stop()
+
+
+@shutdown_decorator
+def shutdown_topics():
+    delete_topics(
+        bootstrap_servers=bootstrap_servers,
+        topics_to_delete=topics,
+        admin_client_config=admin_client_config,
+    )

--- a/bluesky_adaptive/tests/test_adjudicators.py
+++ b/bluesky_adaptive/tests/test_adjudicators.py
@@ -1,0 +1,306 @@
+import time as ttime
+from typing import Sequence, Tuple, Union
+
+from bluesky_kafka import BlueskyConsumer, Publisher
+from bluesky_queueserver_api.http import REManagerAPI
+from databroker.client import BlueskyRun
+from event_model import compose_run
+from numpy.typing import ArrayLike
+
+from bluesky_adaptive.adjudicators.base import AgentByNameAdjudicator, NonredundantAdjudicator
+from bluesky_adaptive.adjudicators.msg import Suggestion
+from bluesky_adaptive.agents.base import Agent, AgentConsumer
+
+KAFKA_TIMEOUT = 30.0  # seconds
+
+
+class NoTiled:
+    class V1:
+        def insert(self, *args, **kwargs):
+            pass
+
+    v1 = V1
+
+
+class TestAgent(Agent):
+    measurement_plan_name = "agent_driven_nap"
+
+    def __init__(self, pub_topic, sub_topic, kafka_bootstrap_servers, broker_authorization_config, qs, **kwargs):
+        kafka_consumer = AgentConsumer(
+            topics=[sub_topic],
+            bootstrap_servers=kafka_bootstrap_servers,
+            group_id="test.communication.group",
+            consumer_config={"auto.offset.reset": "latest"},
+        )
+        kafka_producer = Publisher(
+            topic=pub_topic,
+            bootstrap_servers=kafka_bootstrap_servers,
+            key="",
+            producer_config=broker_authorization_config,
+        )
+        super().__init__(
+            kafka_consumer=kafka_consumer,
+            kafka_producer=kafka_producer,
+            tiled_agent_node=None,
+            tiled_data_node=None,
+            qserver=qs,
+            **kwargs,
+        )
+        self.count = 0
+        self.agent_catalog = NoTiled()
+
+    def no_tiled(*args, **kwargs):
+        pass
+
+    def measurement_plan(self, point: ArrayLike) -> Tuple[str, list, dict]:
+        return self.measurement_plan_name, [1.5], dict()
+
+    def unpack_run(self, run: BlueskyRun) -> Tuple[Union[float, ArrayLike], Union[float, ArrayLike]]:
+        return 0, 0
+
+    def report(self, report_number: int = 0) -> dict:
+        return dict(agent_name=self.instance_name, report=f"report_{report_number}")
+
+    def ask(self, batch_size: int = 1) -> Tuple[dict, Sequence]:
+        return ([dict(agent_name=self.instance_name, report=f"ask_{batch_size}")], [0 for _ in range(batch_size)])
+
+    def tell(self, x, y) -> dict:
+        self.count += 1
+        return dict(x=x, y=y)
+
+    def start(self):
+        """Start without kafka consumer start"""
+        self._compose_run_bundle = compose_run(metadata=self.metadata)
+        self.agent_catalog.v1.insert("start", self._compose_run_bundle.start_doc)
+
+
+class AccumulateAdjudicator(AgentByNameAdjudicator):
+    def __init__(self, *args, qservers, **kwargs):
+        super().__init__(*args, qservers=qservers, **kwargs)
+        self.consumed_documents = []
+
+    def process_document(self, topic, name, doc):
+        self.consumed_documents.append((name, doc))
+        return super().process_document(topic, name, doc)
+
+    def until_len(self):
+        if len(self.consumed_documents) >= 1:
+            return False
+        else:
+            return True
+
+
+def test_accumulate(temporary_topics, kafka_bootstrap_servers, broker_authorization_config):
+    # Smoke test for the kafka comms and acumulation with `continue_polling` function
+    with temporary_topics(topics=["test.adjudicator"]) as (topic,):
+        publisher = Publisher(
+            topic=topic,
+            bootstrap_servers=kafka_bootstrap_servers,
+            producer_config=broker_authorization_config,
+            key=f"{topic}.key",
+        )
+        re_manager = REManagerAPI(http_server_uri=None)
+        re_manager.set_authorization_key(api_key="SECRET")
+        adjudicator = AccumulateAdjudicator(
+            topics=[topic],
+            bootstrap_servers=kafka_bootstrap_servers,
+            group_id="test.communication.group",
+            qservers={"tst": re_manager},
+            consumer_config={"auto.offset.reset": "earliest"},
+        )
+        adjudicator.start(continue_polling=adjudicator.until_len)
+        publisher("name", {"dfi": "Dfs"})
+        publisher("name", {"dfi": "Dfs"})
+        start_time = ttime.monotonic()
+        while adjudicator.until_len():
+            ttime.sleep(0.5)
+            if ttime.monotonic() - start_time > KAFKA_TIMEOUT:
+                break
+        assert len(adjudicator.consumed_documents) == 1
+
+
+def test_send_to_adjudicator(temporary_topics, kafka_bootstrap_servers, broker_authorization_config):
+    def consume_until_len(kafka_topic, length):
+        consumed_documents = []
+        start_time = ttime.monotonic()
+
+        def process_document(consumer, topic, name, document):
+            consumed_documents.append((name, document))
+
+        consumer = BlueskyConsumer(
+            topics=[kafka_topic],
+            bootstrap_servers=kafka_bootstrap_servers,
+            group_id=f"{kafka_topic}.consumer.group",
+            consumer_config={"auto.offset.reset": "earliest"},
+            process_document=process_document,
+        )
+
+        def until_len():
+            if len(consumed_documents) >= length:
+                return False
+            elif ttime.monotonic() - start_time > KAFKA_TIMEOUT:
+                raise TimeoutError("Kafka Timeout in test environment")
+            else:
+                return True
+
+        consumer.start(continue_polling=until_len)
+        return consumed_documents
+
+    # Test the internal publisher
+    with temporary_topics(topics=["test.adjudicator", "test.data"]) as (adj_topic, bs_topic):
+        agent = TestAgent(adj_topic, bs_topic, kafka_bootstrap_servers, broker_authorization_config, None)
+        agent.kafka_producer("test", {"some": "dict"})
+        cache = consume_until_len(kafka_topic=adj_topic, length=1)
+        assert len(cache) == 1
+
+    # Test agent sending to adjudicator
+    with temporary_topics(topics=["test.adjudicator", "test.data"]) as (adj_topic, bs_topic):
+        agent = TestAgent(adj_topic, bs_topic, kafka_bootstrap_servers, broker_authorization_config, None)
+        agent.start()
+        agent.generate_suggestions_for_adjudicator(1)
+        cache = consume_until_len(kafka_topic=adj_topic, length=1)
+        assert len(cache) == 1
+
+
+def test_adjudicator_receipt(temporary_topics, kafka_bootstrap_servers, broker_authorization_config):
+    # Test agent sending to adjudicator
+    with temporary_topics(topics=["test.adjudicator", "test.data"]) as (adj_topic, bs_topic):
+        agent = TestAgent(adj_topic, bs_topic, kafka_bootstrap_servers, broker_authorization_config, None)
+        agent.start()
+        adjudicator = AccumulateAdjudicator(
+            topics=[adj_topic],
+            bootstrap_servers=kafka_bootstrap_servers,
+            group_id="test.communication.group",
+            qservers={"tst": None},
+            consumer_config={"auto.offset.reset": "earliest"},
+        )
+        adjudicator.start(continue_polling=adjudicator.until_len)
+        agent.generate_suggestions_for_adjudicator(1)
+        start_time = ttime.monotonic()
+        while adjudicator.until_len():
+            ttime.sleep(0.5)
+            if ttime.monotonic() - start_time > KAFKA_TIMEOUT:
+                raise TimeoutError("Adjudicator did not accumulate suggestions")
+        assert len(adjudicator.consumed_documents) == 1
+
+
+def test_adjudicator_by_name(temporary_topics, kafka_bootstrap_servers, broker_authorization_config):
+    with temporary_topics(topics=["test.adjudicator", "test.data"]) as (adj_topic, bs_topic):
+        re_manager = REManagerAPI(http_server_uri=None)
+        re_manager.set_authorization_key(api_key="SECRET")
+        adjudicator = AccumulateAdjudicator(
+            topics=[adj_topic],
+            bootstrap_servers=kafka_bootstrap_servers,
+            group_id="test.communication.group",
+            qservers={"tst": re_manager},
+            consumer_config={"auto.offset.reset": "earliest"},
+        )
+        adjudicator.primary_agent = "good"
+        adjudicator.prompt_judgment = False
+        adjudicator.start()
+
+        good_agent = TestAgent(
+            adj_topic,
+            bs_topic,
+            kafka_bootstrap_servers,
+            broker_authorization_config,
+            re_manager,
+            endstation_key="tst",
+        )
+        good_agent.instance_name = "good"
+        good_agent.start()
+        evil_agent = TestAgent(
+            adj_topic,
+            bs_topic,
+            kafka_bootstrap_servers,
+            broker_authorization_config,
+            re_manager,
+            endstation_key="tst",
+        )
+        evil_agent.instance_name = "evil"
+        evil_agent.start()
+
+        re_manager = good_agent.re_manager
+        status = re_manager.status()
+        if not status["worker_environment_exists"]:
+            re_manager.environment_open()
+        re_manager.queue_clear()
+
+        # Make sure we can put something on the queue from the adjudicator
+        adjudicator._add_suggestion_to_queue(
+            re_manager,
+            "good",
+            Suggestion(ask_uid="test", plan_name="agent_driven_nap", plan_args=[1.5], plan_kwargs={}),
+        )
+        assert re_manager.status()["items_in_queue"] == 1
+
+        # Make sure suggestions are making it to adjudicator
+        good_agent.generate_suggestions_for_adjudicator(1)
+        start_time = ttime.monotonic()
+        while not adjudicator.consumed_documents:
+            ttime.sleep(0.1)
+            if ttime.monotonic() - start_time > KAFKA_TIMEOUT:
+                raise TimeoutError("Adjudicator did not accumulate suggestions")
+        assert adjudicator.current_suggestions
+        assert "good" in adjudicator.agent_names
+
+        # Make sure adjudicator can throw the right suggestions onto the queue
+        good_agent.generate_suggestions_for_adjudicator(1)
+        evil_agent.generate_suggestions_for_adjudicator(1)
+        start_time = ttime.monotonic()
+        while len(adjudicator.current_suggestions) < 2:
+            ttime.sleep(0.1)
+            if ttime.monotonic() - start_time > KAFKA_TIMEOUT:
+                raise TimeoutError("Adjudicator did not accumulate suggestions")
+        judgments = adjudicator.make_judgments()
+        assert adjudicator.primary_agent in adjudicator.current_suggestions.keys()
+        assert len(judgments) == 1
+        assert judgments[0].agent_name == "good"
+        assert judgments[0].re_manager == re_manager
+
+
+def test_nonredundant_adjudicator(temporary_topics, kafka_bootstrap_servers, broker_authorization_config):
+    def _hash_suggestion(tla, suggestion: Suggestion):
+        return f"{tla} {suggestion.plan_name} {str(suggestion.plan_args)}"
+
+    with temporary_topics(topics=["test.adjudicator", "test.data"]) as (adj_topic, bs_topic):
+        re_manager = REManagerAPI(http_server_uri=None)
+        re_manager.set_authorization_key(api_key="SECRET")
+        adjudicator = NonredundantAdjudicator(
+            topics=[adj_topic],
+            bootstrap_servers=kafka_bootstrap_servers,
+            group_id="test.communication.group",
+            qservers={"tst": re_manager},
+            consumer_config={"auto.offset.reset": "earliest"},
+            hash_suggestion=_hash_suggestion,
+        )
+        adjudicator.prompt_judgment = False
+        adjudicator.start()
+        agent = TestAgent(
+            adj_topic,
+            bs_topic,
+            kafka_bootstrap_servers,
+            broker_authorization_config,
+            re_manager,
+            endstation_key="tst",
+        )
+        agent.start()
+        # Assure 5 suggestions that are the same only land as 1 judgement
+        agent.generate_suggestions_for_adjudicator(5)
+        start_time = ttime.monotonic()
+        while not adjudicator.current_suggestions:
+            ttime.sleep(0.1)
+            if ttime.monotonic() - start_time > KAFKA_TIMEOUT:
+                raise TimeoutError("Adjudicator did not accumulate suggestions")
+        judgments = adjudicator.make_judgments()
+        assert len(judgments) == 1
+
+        # Assure that additional suggestions don't pass judgement
+        agent.generate_suggestions_for_adjudicator(1)
+        start_time = ttime.monotonic()
+        while not adjudicator.current_suggestions:
+            ttime.sleep(0.1)
+            if ttime.monotonic() - start_time > KAFKA_TIMEOUT:
+                raise TimeoutError("Adjudicator did not accumulate suggestions")
+        judgments = adjudicator.make_judgments()
+        assert len(judgments) == 0

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ bluesky-queueserver-api
 xkcdpass
 tiled
 numpy
+pydantic


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Add adjudicator base class and two simple subclasses in preparation for joint BMM/PDF experiment. 

## Description
<!--- Describe your changes in detail -->
Each adjudicator subclass is required to implement `make_judgments`, which accepts no args or kwargs, and should return a list of tuples that contain the RE manager API, the agent name, and the Suggestion.
These tuples will by validated by Pydantic models, or can be `Judgment` objects.
This enables an agent to suggest many plans at once, to multiple beamlines!
Adjustable properties can be incorperated by the server, allowing for web and caproto control.

`make_judgments` can be called promptly after every new document, or only on user command.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The purpose of an adjudicator is to provide another layer of misdirection between the agents and the RunEngine Manager.
This is not required, as agents can send plans directly to the queue.
Alternatively, many agents can send plans to an adjudicator that acts as a meta-agent, filtering and deciding which plans from many agents make it to the queue.
In this way, the adjudicator acts as an extra experiment manager.
Feedback is not provided directly to the agents (i.e. no two way communication), so this is in effect, much like how high level human management communicates with low level employees.


## Summary of Changes for Release Notes
<!--- Brief summary of changes that could be copied to the Release Notes. -->
<!--- Skip this section if this is a maintenace PR (CI, unit tests, typo fix etc.) -->
<!--- PRs with feature changes will not be merged without this section filled. -->

<!--- Group the changes in the following sections: -->

### Fixed

### Added
- [x] Adjudicators
- [x] README to describe intent
- [x]  Pydantic validation of messaging
- [x] Agents sending to adjudicator instead of queue
### Changed

### Removed

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tested using `docker-compose up` from testing folder.
### TODO: 
- [x] Test sending plans to non-redundant adjudicator
- [x] Test sending plans to agent preferential adjudicator
- [x] Test launching adjudicator with uvicorn
<!--
## Screenshots (if appropriate):
-->
