### PR TITLE
Make IOC server optional

### DIFF
--- a/bluesky_adaptive/server/server.py
+++ b/bluesky_adaptive/server/server.py
@@ -17,6 +17,20 @@ ioc_server = None
 worker_shutdown_timeout = 5
 
 
+def to_boolean(value):
+    """
+    Returns ``True`` or ``False`` if ``value`` is found in one of the lists of supported values.
+    Otherwise returns ``None`` (typicall means that the value is not set).
+    """
+    v = value.lower() if isinstance(value, str) else value
+    if v in (True, "y", "yes", "t", "true", "on", "1"):
+        return True
+    elif v in (False, "", "n", "no", "f", "false", "off", "0"):
+        return False
+    else:
+        return None
+
+
 def create_conn_pipes():
     server_conn, worker_conn = Pipe()
     return server_conn, worker_conn
@@ -41,7 +55,7 @@ def build_app():
         logger.info("Starting the server ...")
 
         ioc_prefix = os.environ.get("BS_AGENT_IOC_PREFIX", "agent_ioc")
-        start_ioc_server = os.environ.get("BS_AGENT_START_IOC_SERVER", False)
+        start_ioc_server = to_boolean(os.environ.get("BS_AGENT_START_IOC_SERVER", "false"))
         startup_script_path = os.environ.get("BS_AGENT_STARTUP_SCRIPT_PATH", None)
         startup_module_name = os.environ.get("BS_AGENT_STARTUP_MODULE_NAME", None)
         worker_shutdown_timeout = os.environ.get("BS_AGENT_WORKER_SHUTDOWN_TIMEOUT", 5)

--- a/bluesky_adaptive/server/worker.py
+++ b/bluesky_adaptive/server/worker.py
@@ -414,7 +414,7 @@ class WorkerProcess(Process):
             success = False
 
         if success:
-            logger.info("RE Environment is ready")
+            logger.info("Agent environment is ready")
             self._execute_in_main_thread()
 
         self._env_state = EState.CLOSING


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Make IOC server optional. The IOC server is not started by default. Set the environment variable
`BS_AGENT_START_IOC_SERVER=true` to enable the IOC server.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Summary of Changes for Release Notes
<!--- Brief summary of changes that could be copied to the Release Notes. -->
<!--- Skip this section if this is a maintenace PR (CI, unit tests, typo fix etc.) -->
<!--- PRs with feature changes will not be merged without this section filled. -->

<!--- Group the changes in the following sections: -->

### Fixed

### Added

- Environment variable `BS_AGENT_START_IOC_SERVER` (boolean) controls whether the IOC server is started. The IOC server is optional and not started by default. Set the environment variable `true` to enable the server.

### Changed

### Removed

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

<!--
## Screenshots (if appropriate):
-->
