### PR TITLE
mnt: gha for docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -45,7 +45,7 @@ jobs:
 
 
     - name: Deploy documentation to blueskyproject.io.
-      if: github.repository_owner == 'bluesky' && github.ref_name == 'master'
+      if: github.repository_owner == 'bluesky' && github.ref_name == 'main'
       # We pin to the SHA, not the tag, for security reasons.
       # https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/security-hardening-for-github-actions#using-third-party-actions
       uses: peaceiris/actions-gh-pages@bbdfb200618d235585ad98e965f4aafc39b4c501 # v3.7.3

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -52,7 +52,7 @@ jobs:
       with:
         deploy_key: ${{ secrets.ACTIONS_DOCUMENTATION_DEPLOY_KEY }}
         publish_branch: master
-        publish_dir: build/html
+        publish_dir: ./docs/build/html
         external_repository: bluesky/bluesky.github.io
         destination_dir: ${{ env.REPOSITORY_NAME }} # just the repo name, without the "bluesky/"
         keep_files: true # Keep old files.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixes GHA for docs with correct pathname for compiled docs and branch name. Manually checked to ensure pushed to [`bluesky/bluesky.github.io`](https://github.com/bluesky/bluesky.github.io)
