### PR TITLE
feat: add functionality for pausing/stoping/aborting per event

### DIFF
--- a/bluesky_adaptive/per_event.py
+++ b/bluesky_adaptive/per_event.py
@@ -85,6 +85,9 @@ def recommender_factory(recommender, independent_keys, dependent_keys, *, max_co
             except RunEngineControlException as e:
                 # Recommendation to stop/abort/pause
                 queue.put(e)
+            except Exception as e:
+                # Some other exception will be raised by the plan
+                queue.put(e)
             else:
                 queue.put({k: v for k, v in zip(independent_keys, next_point)})
 

--- a/bluesky_adaptive/per_event.py
+++ b/bluesky_adaptive/per_event.py
@@ -19,7 +19,7 @@ import bluesky.preprocessors as bpp
 from bluesky.utils import RunEngineControlException
 from event_model import RunRouter
 
-from .recommendations import NoRecommendation, RecommendedPause
+from .recommendations import NoRecommendation, RequestPause
 from .utils import extract_event_page
 
 
@@ -167,7 +167,7 @@ def adaptive_plan(
             next_point = from_recommender.get(timeout=1)
             if next_point is None:
                 return
-            elif isinstance(next_point, RecommendedPause):
+            elif isinstance(next_point, RequestPause):
                 yield from bps.pause()
             elif isinstance(next_point, Exception):
                 raise next_point

--- a/bluesky_adaptive/recommendations.py
+++ b/bluesky_adaptive/recommendations.py
@@ -1,8 +1,15 @@
 """Toy recommendation engines for testing / demo purposes."""
+from bluesky.utils import RunEngineControlException
 
 
 class NoRecommendation(Exception):
     """Exception to signal we have no recommended action."""
+
+    ...
+
+
+class RecommendedPause(RunEngineControlException):
+    """Exception to signal that we recommend pausing the plan"""
 
     ...
 

--- a/bluesky_adaptive/recommendations.py
+++ b/bluesky_adaptive/recommendations.py
@@ -8,7 +8,7 @@ class NoRecommendation(Exception):
     ...
 
 
-class RecommendedPause(RunEngineControlException):
+class RequestPause(RunEngineControlException):
     """Exception to signal that we recommend pausing the plan"""
 
     ...

--- a/bluesky_adaptive/tests/test_per_event.py
+++ b/bluesky_adaptive/tests/test_per_event.py
@@ -3,7 +3,7 @@ from bluesky.tests.utils import DocCollector
 from bluesky.utils import RequestAbort, RequestStop, RunEngineInterrupted
 
 from bluesky_adaptive.per_event import adaptive_plan, recommender_factory
-from bluesky_adaptive.recommendations import RecommendedPause, SequenceRecommender
+from bluesky_adaptive.recommendations import RequestPause, SequenceRecommender
 
 
 def test_seq_recommender(RE, hw):
@@ -107,7 +107,7 @@ class PauseSequenceRecommender(SequenceRecommender):
     def ask(self, *args, **kwargs):
         next_point = super().ask(*args, **kwargs)
         if any([p > 2 for p in next_point]):
-            raise RecommendedPause("Too big!")
+            raise RequestPause("Too big!")
         else:
             return next_point
 

--- a/bluesky_adaptive/tests/test_per_event.py
+++ b/bluesky_adaptive/tests/test_per_event.py
@@ -1,7 +1,9 @@
+import pytest
 from bluesky.tests.utils import DocCollector
+from bluesky.utils import RequestAbort, RequestStop, RunEngineInterrupted
 
 from bluesky_adaptive.per_event import adaptive_plan, recommender_factory
-from bluesky_adaptive.recommendations import SequenceRecommender
+from bluesky_adaptive.recommendations import RecommendedPause, SequenceRecommender
 
 
 def test_seq_recommender(RE, hw):
@@ -31,3 +33,104 @@ def test_seq_recommender(RE, hw):
     assert len(dc.event) == 1
     (events,) = dc.event.values()
     assert len(events) == 4
+
+
+class StopSequenceRecommender(SequenceRecommender):
+    """Test sequence recommender that aborts if the reccomendation gets too big"""
+
+    def ask(self, *args, **kwargs):
+        next_point = super().ask(*args, **kwargs)
+        if any([p > 2 for p in next_point]):
+            raise RequestStop("Too big!")
+        else:
+            return next_point
+
+
+def test_seq_recommender_stop(RE, hw):
+    recommender = StopSequenceRecommender(
+        [
+            [1],
+            [2],
+            [3],
+        ]
+    )
+    cb, queue = recommender_factory(recommender, ["motor"], ["det"])
+    dc = DocCollector()
+
+    RE(
+        adaptive_plan([hw.det], {hw.motor: 0}, to_recommender=cb, from_recommender=queue),
+        dc.insert,
+    )
+    assert len(dc.start) == 1
+    assert len(dc.event) == 1
+    (events,) = dc.event.values()
+    assert len(events) == 3
+    assert list(dc.stop.values())[0]["exit_status"] == "success"
+
+
+class AbortSequenceRecommender(SequenceRecommender):
+    """Test sequence recommender that aborts if the reccomendation gets too big"""
+
+    def ask(self, *args, **kwargs):
+        next_point = super().ask(*args, **kwargs)
+        if any([p > 2 for p in next_point]):
+            raise RequestAbort("Too big!")
+        else:
+            return next_point
+
+
+def test_seq_recommender_abort(RE, hw):
+    recommender = AbortSequenceRecommender(
+        [
+            [1],
+            [2],
+            [3],
+        ]
+    )
+    cb, queue = recommender_factory(recommender, ["motor"], ["det"])
+    dc = DocCollector()
+
+    RE(
+        adaptive_plan([hw.det], {hw.motor: 0}, to_recommender=cb, from_recommender=queue),
+        dc.insert,
+    )
+    assert len(dc.start) == 1
+    assert len(dc.event) == 1
+    (events,) = dc.event.values()
+    assert len(events) == 3
+    assert list(dc.stop.values())[0]["exit_status"] == "abort"
+
+
+class PauseSequenceRecommender(SequenceRecommender):
+    """Test sequence recommender that aborts if the reccomendation gets too big"""
+
+    def ask(self, *args, **kwargs):
+        next_point = super().ask(*args, **kwargs)
+        if any([p > 2 for p in next_point]):
+            raise RecommendedPause("Too big!")
+        else:
+            return next_point
+
+
+def test_seq_recommender_pause(RE, hw):
+    recommender = PauseSequenceRecommender(
+        [
+            [1],
+            [2],
+            [3],
+        ]
+    )
+    cb, queue = recommender_factory(recommender, ["motor"], ["det"])
+    dc = DocCollector()
+
+    with pytest.raises(RunEngineInterrupted):
+        RE(
+            adaptive_plan([hw.det], {hw.motor: 0}, to_recommender=cb, from_recommender=queue),
+            dc.insert,
+        )
+
+    assert len(dc.start) == 1
+    assert len(dc.event) == 1
+    (events,) = dc.event.values()
+    assert len(events) == 3
+    assert RE.state == "paused"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
In response to [this Mattermost issue](https://mattermost.hzdr.de/bluesky/pl/dp3tq9pn4pfwin951e9iy69dco), adds the ability for an adaptive eventwise plan to pause, stop, or abort. 

## Description
<!--- Describe your changes in detail -->
- Adds `RequestPause` as subclass of RunEngineControlException
- doc/refactor: removes gp assumptions from syntax
- Adds None to queue for completion
- Raises exceptions to RE to be processed accordingly (i.e., `RequestStop`, `RequestAbort`)
- Uses the `RequestPause` error to `yield from bps.pause()`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This may be overkill for the issue @untzag had, but it is a broadly applicable need. 

## Summary of Changes for Release Notes
<!--- Brief summary of changes that could be copied to the Release Notes. -->
<!--- Skip this section if this is a maintenace PR (CI, unit tests, typo fix etc.) -->
<!--- PRs with feature changes will not be merged without this section filled. -->
Add per-event adaptive functionality to handle stopping/aborting/pausing the RunEngine

<!--- Group the changes in the following sections: -->

### Fixed
- doc/refactor: removes gp assumptions from syntax

### Added
Adds `RequestPause` as subclass of RunEngineControlException

### Changed
-  Raises exceptions to RE to be processed accordingly (i.e., `RequestStop`, `RequestAbort`)
- Uses the `RequestPause` error to `yield from bps.pause()`

### Removed

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Additional unit tests. Expect CI/CD via GHA to still fail, but these tests pass locally.

<!--
## Screenshots (if appropriate):
-->
