### PR TITLE
Make per start and per stop compatible with Queue Server

### DIFF
--- a/bluesky_adaptive/per_event.py
+++ b/bluesky_adaptive/per_event.py
@@ -88,9 +88,7 @@ def recommender_factory(recommender, independent_keys, dependent_keys, *, max_co
     return rr, queue
 
 
-def adaptive_plan(
-    dets, first_point, *, to_recommender, from_recommender, md=None, take_reading=bps.trigger_and_read
-):
+def adaptive_plan(dets, first_point, *, to_recommender, from_recommender, md=None, take_reading=None):
     """
     Execute an adaptive scan using an per event-run recommendation engine.
 
@@ -136,6 +134,9 @@ def adaptive_plan(
 
         Defaults to `bluesky.plan_stubs.trigger_and_read`
     """
+    if take_reading is None:
+        take_reading = bps.trigger_and_read
+
     # TODO inject args / kwargs here.
     _md = {"hints": {}}
     _md.update(md or {})

--- a/bluesky_adaptive/per_start.py
+++ b/bluesky_adaptive/per_start.py
@@ -12,6 +12,7 @@ dictates.
 This corresponds to a "middle" scale of adaptive integration into
 data collection.
 """
+
 import itertools
 import uuid
 from queue import Empty, Queue
@@ -105,7 +106,7 @@ def recommender_factory(adaptive_obj, independent_keys, dependent_keys, *, max_c
     return rr, queue
 
 
-def adaptive_plan(dets, first_point, *, to_recommender, from_recommender, md=None, take_reading=bp.count):
+def adaptive_plan(dets, first_point, *, to_recommender, from_recommender, md=None, take_reading=None):
     """
     Execute an adaptive scan using an inter-run recommendation engine.
 
@@ -151,6 +152,8 @@ def adaptive_plan(dets, first_point, *, to_recommender, from_recommender, md=Non
         Defaults to `bluesky.plans.count`
 
     """
+    if take_reading is None:
+        take_reading = bp.count
     # extract the motors
     motors = list(first_point.keys())
     # convert the first_point variable to from we will be getting


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->


## Description
<!--- Describe your changes in detail -->
Queueserver cannot parse a callable (i.e., plans) as default argument in the definition of a plan. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Came up in Bluesky Pods. There is a world in which we want a "fast" adaptive plan put on the queue by a "slow" adaptive agent. 

## Summary of Changes for Release Notes
<!--- Brief summary of changes that could be copied to the Release Notes. -->
<!--- Skip this section if this is a maintenace PR (CI, unit tests, typo fix etc.) -->
<!--- PRs with feature changes will not be merged without this section filled. -->

<!--- Group the changes in the following sections: -->

### Fixed
Queue Server compatibility for per start and per stop plans

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Mounted into the startup dir of bluesky pods, and environment opened. 

<!--
## Screenshots (if appropriate):
-->
