### PR TITLE
CI: add docs publishing workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.x'
+          python-version: '3.12'
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,6 +15,8 @@ on:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
 
@@ -26,7 +28,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install .[dev]
+          pip install .[dev,agents]
 
       - name: Build documentation
         working-directory: docs

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -52,7 +52,7 @@ jobs:
         with:
           deploy_key: ${{ secrets.ACTIONS_DOCUMENTATION_DEPLOY_KEY }}
           publish_branch: master
-          publish_dir: build/html
+          publish_dir: docs/build/html
           external_repository: bluesky/bluesky.github.io
           destination_dir: ${{ env.REPOSITORY_NAME }} # just the repo name, without the "bluesky/"
           keep_files: true # Keep old files.

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,55 @@
+name: Documentation
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'docs/**'
+      - 'bluesky_adaptive/**'
+      - 'pyproject.toml'
+  workflow_dispatch:
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install .[dev]
+
+      - name: Build documentation
+        working-directory: docs
+        run: |
+          make html
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: documentation
+          path: docs/build/html
+
+      - name: Set env.REPOSITORY_NAME # just the repo, as opposed to org/repo
+        run: echo "REPOSITORY_NAME=${GITHUB_REPOSITORY#*/}" >> $GITHUB_ENV
+
+      - name: Deploy documentation to blueskyproject.io.
+        if: github.repository_owner == 'bluesky' && github.ref_name == 'main'
+        # We pin to the SHA, not the tag, for security reasons.
+        # https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/security-hardening-for-github-actions#using-third-party-actions
+        uses: peaceiris/actions-gh-pages@bbdfb200618d235585ad98e965f4aafc39b4c501 # v3.7.3
+        with:
+          deploy_key: ${{ secrets.ACTIONS_DOCUMENTATION_DEPLOY_KEY }}
+          publish_branch: master
+          publish_dir: build/html
+          external_repository: bluesky/bluesky.github.io
+          destination_dir: ${{ env.REPOSITORY_NAME }} # just the repo name, without the "bluesky/"
+          keep_files: true # Keep old files.
+          force_orphan: false # Keep git history.

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,6 +6,7 @@ on:
       - main
       - ci-add-docs-publishing-workflow  # for testing
     paths:
+      - '.github/workflows/docs.yml'  # for testing
       - 'docs/**'
       - 'bluesky_adaptive/**'
       - 'pyproject.toml'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - ci-add-docs-publishing-workflow  # for testing
     paths:
       - 'docs/**'
       - 'bluesky_adaptive/**'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -45,7 +45,7 @@ jobs:
         run: echo "REPOSITORY_NAME=${GITHUB_REPOSITORY#*/}" >> $GITHUB_ENV
 
       - name: Deploy documentation to blueskyproject.io.
-        if: github.repository_owner == 'bluesky' && github.ref_name == 'main'
+        if: github.repository_owner == 'bluesky'
         # We pin to the SHA, not the tag, for security reasons.
         # https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/security-hardening-for-github-actions#using-third-party-actions
         uses: peaceiris/actions-gh-pages@bbdfb200618d235585ad98e965f4aafc39b4c501 # v3.7.3

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,9 +4,7 @@ on:
   push:
     branches:
       - main
-      - ci-add-docs-publishing-workflow  # for testing
     paths:
-      - '.github/workflows/docs.yml'  # for testing
       - 'docs/**'
       - 'bluesky_adaptive/**'
       - 'pyproject.toml'

--- a/bluesky_adaptive/tests/podman/docker-compose.yml
+++ b/bluesky_adaptive/tests/podman/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.2"
 
 services:
   kafka:
-    image: "docker.io/bitnami/kafka:latest"
+    image: "docker.io/bitnamilegacy/kafka:latest"
     ports:
       - "9092:9092"
       - "29092:29092"


### PR DESCRIPTION
The docs have been published at https://blueskyproject.io/bluesky-adaptive/reference/example-agents.html#tsuchinoko-agent via https://github.com/bluesky/bluesky-adaptive/actions/runs/18990579868/job/54242720722 (with the updates before the [f903090](https://github.com/bluesky/bluesky-adaptive/pull/59/commits/f9030906cb2b88832a5d18d9853b458f3d80150f) commit).